### PR TITLE
Data preview attachment, custom link, validation tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,8 +9,8 @@ on:
 concurrency: ci-${{ github.ref }} # to avoid tag collisions in the ECR
 env:
   # repository variables:
-  KBC_DEVELOPERPORTAL_APP: "kds-team.app-email-smtp-sender" # replace with your component id
-  KBC_DEVELOPERPORTAL_VENDOR: "kds-team" # replace with your vendor
+  KBC_DEVELOPERPORTAL_APP: "kds-team.app-email-smtp-sender"
+  KBC_DEVELOPERPORTAL_VENDOR: "kds-team"
   DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
   KBC_DEVELOPERPORTAL_USERNAME: "kds-team+github"
 
@@ -63,7 +63,7 @@ jobs:
       - name: Set image tag
         id: tag
         run: |
-          TAG="${GITHUB_REF##*/}"
+          TAG="${GITHUB_REF##*/}-${{ github.run_number }}"
           IS_SEMANTIC_TAG=$(echo "$TAG" | grep -q '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
           echo "is_semantic_tag=$IS_SEMANTIC_TAG" | tee -a $GITHUB_OUTPUT
           echo "app_image_tag=$TAG" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -129,7 +129,7 @@ jobs:
           docker image ls -a
           docker run ${{ env.KBC_DEVELOPERPORTAL_APP }}:latest ruff check .
           echo "Running unit-tests..."
-          docker run ${{ env.KBC_DEVELOPERPORTAL_APP }}:latest python -m unittest discover
+          docker run ${{ env.KBC_DEVELOPERPORTAL_APP }}:latest pytest
 
   tests-kbc:
     name: Run KBC Tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set image tag
         id: tag
         run: |
-          TAG="${GITHUB_REF##*/}-${{ github.run_number }}"
+          TAG="${GITHUB_REF##*/}"
           IS_SEMANTIC_TAG=$(echo "$TAG" | grep -q '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
           echo "is_semantic_tag=$IS_SEMANTIC_TAG" | tee -a $GITHUB_OUTPUT
           echo "app_image_tag=$TAG" | tee -a $GITHUB_OUTPUT

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -299,17 +299,71 @@
             }
           }
         },
+        "include_custom_link": {
+          "type": "boolean",
+          "title": "Include Custom Link",
+          "format": "checkbox",
+          "default": false,
+          "propertyOrder": 5
+        },
+        "custom_link_text": {
+          "type": "string",
+          "title": "Link Text",
+          "default": "Storage Link",
+          "propertyOrder": 6,
+          "options": {
+            "dependencies": {
+              "include_custom_link": true
+            }
+          }
+        },
+        "custom_link_url": {
+          "type": "string",
+          "title": "Link URL Template",
+          "description": "Example: <code>https://{stack}/admin/projects/{project_id}/table-preview/{table_id}?context=%2Fqueue%2F{run_id}</code>",
+          "default": "",
+          "propertyOrder": 7,
+          "options": {
+            "tooltip": "Available placeholders:\n- <code>{stack}</code> - Keboola stack hostname\n- <code>{project_id}</code> - Current project ID\n- <code>{table_id}</code> - Storage table ID (requires table selection)\n- <code>{run_id}</code> - Current job run ID",
+            "dependencies": {
+              "include_custom_link": true
+            }
+          }
+        },
+        "custom_link_table": {
+          "type": "string",
+          "title": "Table for {table_id} Placeholder",
+          "description": "Select table to use for {table_id} placeholder in URL",
+          "items": {
+            "enum": [],
+            "type": "string"
+          },
+          "enum": [],
+          "format": "select",
+          "uniqueItems": true,
+          "propertyOrder": 8,
+          "options": {
+            "async": {
+              "label": "Re-load tables",
+              "action": "load_input_table_selection",
+              "autoload": []
+            },
+            "dependencies": {
+              "include_custom_link": true
+            }
+          }
+        },
         "include_attachments": {
           "type": "boolean",
           "title": "Include Attachments",
           "format": "checkbox",
           "default": true,
-          "propertyOrder": 5
+          "propertyOrder": 9
         },
         "attachments_config": {
           "title": "Attachments Config",
           "type": "object",
-          "propertyOrder": 6,
+          "propertyOrder": 10,
           "properties": {
             "attachments_source": {
               "title": "Attachments Source",
@@ -421,7 +475,7 @@
           "type": "button",
           "format": "sync-action",
           "description": "Validates the whole config",
-          "propertyOrder": 9,
+          "propertyOrder": 20,
           "options": {
             "async": {
               "label": "VALIDATE CONFIG",

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -299,80 +299,26 @@
             }
           }
         },
-        "include_custom_link": {
-          "type": "boolean",
-          "title": "Include Custom Link",
-          "format": "checkbox",
-          "default": false,
-          "propertyOrder": 5
-        },
-        "custom_link_text": {
-          "type": "string",
-          "title": "Link Text",
-          "default": "Storage Link",
-          "propertyOrder": 6,
-          "options": {
-            "dependencies": {
-              "include_custom_link": true
-            }
-          }
-        },
-        "custom_link_url": {
-          "type": "string",
-          "title": "Link URL Template",
-          "description": "Example: <code>https://{stack}/admin/projects/{project_id}/table-preview/{table_id}?context=%2Fqueue%2F{run_id}</code>",
-          "default": "",
-          "propertyOrder": 7,
-          "options": {
-            "tooltip": "Available placeholders:\n- <code>{stack}</code> - Keboola stack hostname\n- <code>{project_id}</code> - Current project ID\n- <code>{table_id}</code> - Storage table ID (requires table selection)\n- <code>{run_id}</code> - Current job run ID",
-            "dependencies": {
-              "include_custom_link": true
-            }
-          }
-        },
-        "custom_link_table": {
-          "type": "string",
-          "title": "Table for {table_id} Placeholder",
-          "description": "Select table to use for {table_id} placeholder in URL",
-          "items": {
-            "enum": [],
-            "type": "string"
-          },
-          "enum": [],
-          "format": "select",
-          "uniqueItems": true,
-          "propertyOrder": 8,
-          "options": {
-            "async": {
-              "label": "Re-load tables",
-              "action": "load_input_table_selection",
-              "autoload": []
-            },
-            "dependencies": {
-              "include_custom_link": true
-            }
-          }
-        },
         "include_attachments": {
           "type": "boolean",
           "title": "Include Attachments",
           "format": "checkbox",
           "default": true,
-          "propertyOrder": 9
+          "propertyOrder": 5
         },
         "attachments_config": {
           "title": "Attachments Config",
           "type": "object",
-          "propertyOrder": 10,
+          "propertyOrder": 6,
           "properties": {
             "attachments_source": {
               "title": "Attachments Source",
               "type": "string",
               "propertyOrder": 1,
-              "enum": ["from_table", "data_preview", "all_input_files"],
+              "enum": ["from_table", "single_table", "all_input_files"],
               "options": {
-                "enum_titles": ["From Table", "Data Preview", "All Input Files and Tables"],
-                "tooltip": "**From Table** - column expects json list of attachment filenames in input mapping, associated with specific recipients \n- example use case - you want to have control over who receives what - everybody could receive newsletter associated pdf, but certain recipients are eligible for a special offer included in this newsletter\n\n**Data Preview** - attach a CSV file with the first N rows from a selected input table\n\n**All Input Files** - all recipients will receive all non-template files in the input mapping"
+                "enum_titles": ["Table Column", "Single Input Table", "All Input Files and Tables"],
+                "tooltip": "**Table Column** - each recipient gets specific attachments defined in a column (JSON list of filenames)\n- example: personalized attachments per recipient\n\n**Single Input Table** - attach a CSV sample and/or link to a selected input table\n- example: send preview of processed data or link to full table in Storage\n\n**All Input Files** - all recipients receive all non-template files in the input mapping"
               }
             },
             "attachments_column": {
@@ -396,10 +342,10 @@
                 "dependencies": {"attachments_source":  "from_table"}
               }
             },
-            "data_preview_table": {
+            "source_table": {
               "type": "string",
-              "title": "Data Preview Table",
-              "description": "Table to use as data source for preview",
+              "title": "Source Table",
+              "description": "Input table to use as data source",
               "items": {
                 "enum": [],
                 "type": "string"
@@ -414,48 +360,111 @@
                   "action": "load_input_table_selection",
                   "autoload": []
                 },
-                "dependencies": {"attachments_source": "data_preview"}
+                "dependencies": {"attachments_source": "single_table"}
               }
             },
-            "preview_row_limit": {
+            "include_csv_sample": {
+              "type": "boolean",
+              "title": "Include CSV Sample",
+              "description": "Attach a CSV file with the first N rows from the source table",
+              "format": "checkbox",
+              "default": true,
+              "propertyOrder": 4,
+              "options": {
+                "dependencies": {"attachments_source": "single_table"}
+              }
+            },
+            "sample_row_limit": {
               "type": "integer",
-              "title": "Preview Row Limit",
-              "description": "Number of rows to include in preview (1-1000)",
+              "title": "Sample Row Limit",
+              "description": "Number of rows to include in sample (1-1000)",
               "default": 100,
               "minimum": 1,
               "maximum": 1000,
-              "propertyOrder": 4,
-              "options": {
-                "dependencies": {"attachments_source": "data_preview"}
-              }
-            },
-            "preview_attachment_filename": {
-              "type": "string",
-              "title": "Preview Attachment Filename",
-              "description": "Filename for the CSV preview. Use {table_name} placeholder.",
-              "default": "{table_name}_preview.csv",
               "propertyOrder": 5,
               "options": {
-                "dependencies": {"attachments_source": "data_preview"}
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
               }
             },
-            "preview_info_text": {
-              "type": "string",
-              "title": "Preview Info Text",
-              "description": "Text appended to email body. Use {n} for preview rows, {total} for total rows.",
-              "default": "Attachment contains {n} of {total} records.",
-              "format": "textarea",
+            "sample_sort_enabled": {
+              "type": "boolean",
+              "title": "Sort Sample",
+              "format": "checkbox",
+              "default": false,
               "propertyOrder": 6,
               "options": {
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
+              }
+            },
+            "sample_sort_column": {
+              "type": "string",
+              "title": "Sort by Column",
+              "items": {
+                "enum": [],
+                "type": "string"
+              },
+              "enum": [],
+              "format": "select",
+              "uniqueItems": true,
+              "propertyOrder": 7,
+              "options": {
+                "async": {
+                  "label": "Re-load columns",
+                  "action": "load_source_table_columns",
+                  "autoload": ["parameters.advanced_options.attachments_config.source_table"]
+                },
+                "dependencies": {"include_csv_sample": true, "sample_sort_enabled": true}
+              }
+            },
+            "sample_sort_order": {
+              "type": "string",
+              "title": "Sort Order",
+              "enum": ["asc", "desc"],
+              "default": "asc",
+              "propertyOrder": 8,
+              "options": {
+                "enum_titles": ["Ascending", "Descending"],
+                "dependencies": {"include_csv_sample": true, "sample_sort_enabled": true}
+              }
+            },
+            "sample_attachment_filename": {
+              "type": "string",
+              "title": "Sample Attachment Filename",
+              "description": "Filename for the CSV sample. Use {table_name} placeholder.",
+              "default": "{table_name}_sample.csv",
+              "propertyOrder": 9,
+              "options": {
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
+              }
+            },
+            "sample_info_text": {
+              "type": "string",
+              "title": "Sample Info Text",
+              "description": "Text appended to email body. Use {n} for sample rows, {total} for total rows.",
+              "default": "Attachment contains {n} of {total} records.",
+              "format": "textarea",
+              "propertyOrder": 10,
+              "options": {
                 "input_height": "100px",
-                "dependencies": {"attachments_source": "data_preview"}
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
+              }
+            },
+            "include_snapshot_link": {
+              "type": "boolean",
+              "title": "Include Link to Table Snapshot",
+              "description": "Appends a link to view the full table data as captured at the time of this job run",
+              "format": "checkbox",
+              "default": false,
+              "propertyOrder": 11,
+              "options": {
+                "dependencies": {"attachments_source": "single_table"}
               }
             },
             "validate_attachments": {
               "type": "button",
               "format": "sync-action",
               "description": "Validates All attachments are present in file input mapping (excluding the template files)",
-              "propertyOrder": 7,
+              "propertyOrder": 12,
               "options": {
                 "async": {
                   "label": "VALIDATE ATTACHMENTS",

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -363,13 +363,24 @@
                 "dependencies": {"attachments_source": "single_table"}
               }
             },
+            "include_snapshot_link": {
+              "type": "boolean",
+              "title": "Include Link to Data Snapshot",
+              "description": "Uploads the source table to File Storage and includes a download link in the email body. The snapshot file expires after 15 days.",
+              "format": "checkbox",
+              "default": false,
+              "propertyOrder": 4,
+              "options": {
+                "dependencies": {"attachments_source": "single_table"}
+              }
+            },
             "include_csv_sample": {
               "type": "boolean",
               "title": "Include CSV Sample",
               "description": "Attach a CSV file with the first N rows from the source table",
               "format": "checkbox",
               "default": true,
-              "propertyOrder": 4,
+              "propertyOrder": 5,
               "options": {
                 "dependencies": {"attachments_source": "single_table"}
               }
@@ -381,7 +392,7 @@
               "default": 100,
               "minimum": 1,
               "maximum": 1000,
-              "propertyOrder": 5,
+              "propertyOrder": 6,
               "options": {
                 "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
               }
@@ -391,7 +402,7 @@
               "title": "Sort Sample",
               "format": "checkbox",
               "default": false,
-              "propertyOrder": 6,
+              "propertyOrder": 7,
               "options": {
                 "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
               }
@@ -406,7 +417,7 @@
               "enum": [],
               "format": "select",
               "uniqueItems": true,
-              "propertyOrder": 7,
+              "propertyOrder": 8,
               "options": {
                 "async": {
                   "label": "Re-load columns",
@@ -421,7 +432,7 @@
               "title": "Sort Order",
               "enum": ["asc", "desc"],
               "default": "asc",
-              "propertyOrder": 8,
+              "propertyOrder": 9,
               "options": {
                 "enum_titles": ["Ascending", "Descending"],
                 "dependencies": {"include_csv_sample": true, "sample_sort_enabled": true}
@@ -432,7 +443,7 @@
               "title": "Sample Attachment Filename",
               "description": "Filename for the CSV sample. Use {table_name} placeholder.",
               "default": "{table_name}_sample.csv",
-              "propertyOrder": 9,
+              "propertyOrder": 10,
               "options": {
                 "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
               }
@@ -443,21 +454,10 @@
               "description": "Text appended to email body. Use {n} for sample rows, {total} for total rows.",
               "default": "Attachment contains {n} of {total} records.",
               "format": "textarea",
-              "propertyOrder": 10,
+              "propertyOrder": 11,
               "options": {
                 "input_height": "100px",
                 "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
-              }
-            },
-            "include_snapshot_link": {
-              "type": "boolean",
-              "title": "Include Link to Table Snapshot",
-              "description": "Appends a link to view the full table data as captured at the time of this job run",
-              "format": "checkbox",
-              "default": false,
-              "propertyOrder": 11,
-              "options": {
-                "dependencies": {"attachments_source": "single_table"}
               }
             },
             "validate_attachments": {

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -49,7 +49,7 @@
           "title": "Include Attachments",
           "type": "boolean",
           "format": "checkbox",
-          "description": "if checked - all tables and files in input mapping will be used as attachments",
+          "description": "If checked, all tables and files in input mapping will be used as attachments.",
           "default": true,
           "propertyOrder": 4
         }
@@ -65,7 +65,6 @@
         "email_data_table_name": {
           "type": "string",
           "title": "Email Data Table",
-          "description": "name of the table with recipient email addresses, placeholders, other columns depending on your configuration",
           "items": {
             "enum": [],
             "type": "string"
@@ -80,7 +79,8 @@
               "action": "load_input_table_selection",
               "autoload": []
             },
-            "grid_columns": 6
+            "grid_columns": 6,
+            "tooltip": "Name of the table with recipient email addresses, placeholders, and other columns depending on your configuration."
           }
         },
         "recipient_email_address_column": {
@@ -159,7 +159,7 @@
             "validate_subject": {
                 "type": "button",
                 "format": "sync-action",
-                "description": "Checks, whether all placeholders in your subject template are contained in the input table",
+                "description": "Checks whether all placeholders in your subject template are contained in the input table.",
                 "propertyOrder": 7,
                 "options": {
                   "async": {
@@ -195,7 +195,7 @@
               "type": "boolean",
               "format": "checkbox",
               "title": "Use HTML Template",
-              "description": "HTML version is the primary displayed message, if recipients inbox doesn't support HTML, the message defaults to the plaintext version",
+              "description": "HTML version is the primary displayed message. If recipient's inbox doesn't support HTML, the message defaults to the plaintext version.",
               "default": true,
               "propertyOrder": 7,
               "options": {
@@ -284,7 +284,7 @@
             "validate_plaintext_template": {
               "type": "button",
               "format": "sync-action",
-              "description": "Checks, whether all placeholders in your plaintext template are contained in the input table",
+              "description": "Checks whether all placeholders in your plaintext template are contained in the input table.",
               "propertyOrder": 7,
               "options": {
                 "async": {
@@ -311,7 +311,7 @@
             "validate_html_template": {
               "type": "button",
               "format": "sync-action",
-              "description": "Checks, whether all placeholders in your HTML template are contained in the input table",
+              "description": "Checks whether all placeholders in your HTML template are contained in the input table.",
               "propertyOrder": 9,
               "options": {
                 "async": {
@@ -363,7 +363,7 @@
               "type": "string",
               "title": "Data Column",
               "enum": [],
-              "description": "column expects json list of attachment filenames in input mapping, associated with specific recipients",
+              "description": "Column expects JSON list of attachment filenames in input mapping, associated with specific recipients.",
               "items": {
                 "enum": [],
                 "type": "string"
@@ -384,7 +384,7 @@
             "source_table": {
               "type": "string",
               "title": "Source Table",
-              "description": "Input table to use as data source",
+              "description": "Input table to use as data source.",
               "items": {
                 "enum": [],
                 "type": "string"
@@ -418,7 +418,7 @@
             "include_csv_sample": {
               "type": "boolean",
               "title": "Include CSV Sample",
-              "description": "Include a CSV file with the first N rows from the source table",
+              "description": "Include a CSV file with the first N rows from the source table.",
               "format": "checkbox",
               "default": true,
               "propertyOrder": 5,
@@ -430,7 +430,7 @@
             "sample_row_limit": {
               "type": "integer",
               "title": "Sample Row Limit",
-              "description": "Number of rows to include in sample (1-1000)",
+              "description": "Number of rows to include in sample (1-1000).",
               "default": 100,
               "minimum": 1,
               "maximum": 1000,
@@ -511,7 +511,7 @@
             "validate_attachments": {
               "type": "button",
               "format": "sync-action",
-              "description": "Validates All attachments are present in file input mapping (excluding the template files)",
+              "description": "Validates all attachments are present in file input mapping (excluding template files).",
               "propertyOrder": 12,
               "options": {
                 "async": {
@@ -527,7 +527,7 @@
         "validate_config": {
           "type": "button",
           "format": "sync-action",
-          "description": "Validates the whole config",
+          "description": "Validates the whole config.",
           "propertyOrder": 20,
           "options": {
             "async": {
@@ -543,7 +543,7 @@
       "type": "boolean",
       "format": "checkbox",
       "title": "Dry run",
-      "description": "if checked - only builds emails, but doesn't send them (it's useful because it will output results table containing what would be sent)",
+      "description": "If checked, only builds emails, but doesn't send them (useful because it will output results table containing what would be sent).",
       "default": false,
       "propertyOrder": 7
     },
@@ -551,7 +551,7 @@
       "type": "boolean",
       "format": "checkbox",
       "title": "Continue On Error",
-      "description": "if checked - component doesn't crash on invalid emails, but tries to send the rest of them",
+      "description": "If checked, component doesn't crash on invalid emails, but tries to send the rest of them.",
       "default": true,
       "propertyOrder": 8
     }

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -315,10 +315,10 @@
               "title": "Attachments Source",
               "type": "string",
               "propertyOrder": 1,
-              "enum": ["from_table", "all_input_files"],
+              "enum": ["from_table", "data_preview", "all_input_files"],
               "options": {
-                "enum_titles": ["From Table", "All Input Files and Tables"],
-                "tooltip": "**From Table** - column expects json list of attachment filenames in input mapping, associated with specific recipients \n- example use case - you want to have control over who receives what - everybody could receive newsletter associated pdf, but certain recipients are eligible for a special offer included in this newsletter\n\n**All Input Files** - all recipients will receive all non-template files in the input mapping"
+                "enum_titles": ["From Table", "Data Preview", "All Input Files and Tables"],
+                "tooltip": "**From Table** - column expects json list of attachment filenames in input mapping, associated with specific recipients \n- example use case - you want to have control over who receives what - everybody could receive newsletter associated pdf, but certain recipients are eligible for a special offer included in this newsletter\n\n**Data Preview** - attach a CSV file with the first N rows from a selected input table\n\n**All Input Files** - all recipients will receive all non-template files in the input mapping"
               }
             },
             "attachments_column": {
@@ -342,11 +342,66 @@
                 "dependencies": {"attachments_source":  "from_table"}
               }
             },
+            "data_preview_table": {
+              "type": "string",
+              "title": "Data Preview Table",
+              "description": "Table to use as data source for preview",
+              "items": {
+                "enum": [],
+                "type": "string"
+              },
+              "enum": [],
+              "format": "select",
+              "uniqueItems": true,
+              "propertyOrder": 3,
+              "options": {
+                "async": {
+                  "label": "Re-load tables",
+                  "action": "load_input_table_selection",
+                  "autoload": []
+                },
+                "dependencies": {"attachments_source": "data_preview"}
+              }
+            },
+            "preview_row_limit": {
+              "type": "integer",
+              "title": "Preview Row Limit",
+              "description": "Number of rows to include in preview (1-1000)",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 1000,
+              "propertyOrder": 4,
+              "options": {
+                "dependencies": {"attachments_source": "data_preview"}
+              }
+            },
+            "preview_attachment_filename": {
+              "type": "string",
+              "title": "Preview Attachment Filename",
+              "description": "Filename for the CSV preview. Use {table_name} placeholder.",
+              "default": "{table_name}_preview.csv",
+              "propertyOrder": 5,
+              "options": {
+                "dependencies": {"attachments_source": "data_preview"}
+              }
+            },
+            "preview_info_text": {
+              "type": "string",
+              "title": "Preview Info Text",
+              "description": "Text appended to email body. Use {n} for preview rows, {total} for total rows.",
+              "default": "Attachment contains {n} of {total} records.",
+              "format": "textarea",
+              "propertyOrder": 6,
+              "options": {
+                "input_height": "100px",
+                "dependencies": {"attachments_source": "data_preview"}
+              }
+            },
             "validate_attachments": {
               "type": "button",
               "format": "sync-action",
               "description": "Validates All attachments are present in file input mapping (excluding the template files)",
-              "propertyOrder": 3,
+              "propertyOrder": 7,
               "options": {
                 "async": {
                   "label": "VALIDATE ATTACHMENTS",

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -309,6 +309,7 @@
         "attachments_config": {
           "title": "Attachments Config",
           "type": "object",
+          "format": "grid-strict",
           "propertyOrder": 6,
           "properties": {
             "attachments_source": {
@@ -318,7 +319,8 @@
               "enum": ["from_table", "single_table", "all_input_files"],
               "options": {
                 "enum_titles": ["Table Column", "Single Input Table", "All Input Files and Tables"],
-                "tooltip": "**Table Column** - each recipient gets specific attachments defined in a column (JSON list of filenames)\n- example: personalized attachments per recipient\n\n**Single Input Table** - attach a CSV sample and/or link to a selected input table\n- example: send preview of processed data or link to full table in Storage\n\n**All Input Files** - all recipients receive all non-template files in the input mapping"
+                "tooltip": "**Table Column** - each recipient gets specific attachments defined in a column (JSON list of filenames)\n- example: personalized attachments per recipient\n\n**Single Input Table** - attach a CSV sample and/or link to a selected input table\n- example: send preview of processed data or link to full table in Storage\n\n**All Input Files** - all recipients receive all non-template files in the input mapping",
+                "grid_columns": 12
               }
             },
             "attachments_column": {
@@ -339,7 +341,8 @@
                   "action": "load_input_table_columns",
                   "autoload": ["parameters.advanced_options.email_data_table_name"]
                 },
-                "dependencies": {"attachments_source":  "from_table"}
+                "dependencies": {"attachments_source":  "from_table"},
+                "grid_columns": 12
               }
             },
             "source_table": {
@@ -360,54 +363,22 @@
                   "action": "load_input_table_selection",
                   "autoload": []
                 },
-                "dependencies": {"attachments_source": "single_table"}
+                "dependencies": {"attachments_source": "single_table"},
+                "grid_columns": 12
               }
             },
-            "include_snapshot_link": {
+            "sort_enabled": {
               "type": "boolean",
-              "title": "Include Link to Data Snapshot",
-              "description": "Uploads the source table to File Storage and includes a download link in the email body. The snapshot file expires after 15 days.",
+              "title": "Sort Table",
               "format": "checkbox",
               "default": false,
               "propertyOrder": 4,
               "options": {
-                "dependencies": {"attachments_source": "single_table"}
+                "dependencies": {"attachments_source": "single_table"},
+                "grid_columns": 12
               }
             },
-            "include_csv_sample": {
-              "type": "boolean",
-              "title": "Include CSV Sample",
-              "description": "Attach a CSV file with the first N rows from the source table",
-              "format": "checkbox",
-              "default": true,
-              "propertyOrder": 5,
-              "options": {
-                "dependencies": {"attachments_source": "single_table"}
-              }
-            },
-            "sample_row_limit": {
-              "type": "integer",
-              "title": "Sample Row Limit",
-              "description": "Number of rows to include in sample (1-1000)",
-              "default": 100,
-              "minimum": 1,
-              "maximum": 1000,
-              "propertyOrder": 6,
-              "options": {
-                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
-              }
-            },
-            "sample_sort_enabled": {
-              "type": "boolean",
-              "title": "Sort Sample",
-              "format": "checkbox",
-              "default": false,
-              "propertyOrder": 7,
-              "options": {
-                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
-              }
-            },
-            "sample_sort_column": {
+            "sort_column": {
               "type": "string",
               "title": "Sort by Column",
               "items": {
@@ -417,25 +388,64 @@
               "enum": [],
               "format": "select",
               "uniqueItems": true,
-              "propertyOrder": 8,
+              "propertyOrder": 5,
               "options": {
                 "async": {
                   "label": "Re-load columns",
                   "action": "load_source_table_columns",
                   "autoload": ["parameters.advanced_options.attachments_config.source_table"]
                 },
-                "dependencies": {"include_csv_sample": true, "sample_sort_enabled": true}
+                "dependencies": {"attachments_source": "single_table", "sort_enabled": true},
+                "grid_columns": 9
               }
             },
-            "sample_sort_order": {
+            "sort_order": {
               "type": "string",
               "title": "Sort Order",
               "enum": ["asc", "desc"],
               "default": "asc",
-              "propertyOrder": 9,
+              "propertyOrder": 6,
               "options": {
                 "enum_titles": ["Ascending", "Descending"],
-                "dependencies": {"include_csv_sample": true, "sample_sort_enabled": true}
+                "dependencies": {"attachments_source": "single_table", "sort_enabled": true},
+                "grid_columns": 3
+              }
+            },
+            "include_snapshot_link": {
+              "type": "boolean",
+              "title": "Include Link to Data Snapshot",
+              "description": "Uploads the source table to File Storage and includes a download link in the email body. The snapshot file expires after 15 days.",
+              "format": "checkbox",
+              "default": false,
+              "propertyOrder": 7,
+              "options": {
+                "dependencies": {"attachments_source": "single_table"},
+                "grid_columns": 12
+              }
+            },
+            "include_csv_sample": {
+              "type": "boolean",
+              "title": "Include CSV Sample",
+              "description": "Attach a CSV file with the first N rows from the source table",
+              "format": "checkbox",
+              "default": true,
+              "propertyOrder": 8,
+              "options": {
+                "dependencies": {"attachments_source": "single_table"},
+                "grid_columns": 12
+              }
+            },
+            "sample_row_limit": {
+              "type": "integer",
+              "title": "Sample Row Limit",
+              "description": "Number of rows to include in sample (1-1000)",
+              "default": 100,
+              "minimum": 1,
+              "maximum": 1000,
+              "propertyOrder": 9,
+              "options": {
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true},
+                "grid_columns": 12
               }
             },
             "sample_attachment_filename": {
@@ -445,7 +455,8 @@
               "default": "{table_name}_sample.csv",
               "propertyOrder": 10,
               "options": {
-                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true},
+                "grid_columns": 12
               }
             },
             "sample_info_text": {
@@ -457,7 +468,8 @@
               "propertyOrder": 11,
               "options": {
                 "input_height": "100px",
-                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true}
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true},
+                "grid_columns": 12
               }
             },
             "validate_attachments": {
@@ -470,7 +482,8 @@
                   "label": "VALIDATE ATTACHMENTS",
                   "action": "validate_attachments"
                 },
-                "dependencies": {"attachments_source":  "from_table"}
+                "dependencies": {"attachments_source":  "from_table"},
+                "grid_columns": 12
               }
             }
           },

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -58,12 +58,13 @@
     "advanced_options": {
       "title": "Advanced Options",
       "type": "object",
+      "format": "grid-strict",
       "propertyOrder": 3,
       "options": {"dependencies": {"configuration_type": "advanced"}},
       "properties": {
         "email_data_table_name": {
           "type": "string",
-          "title": "Email Data Table Name",
+          "title": "Email Data Table",
           "description": "name of the table with recipient email addresses, placeholders, other columns depending on your configuration",
           "items": {
             "enum": [],
@@ -78,12 +79,13 @@
               "label": "Re-load tables",
               "action": "load_input_table_selection",
               "autoload": []
-            }
+            },
+            "grid_columns": 6
           }
         },
         "recipient_email_address_column": {
           "type": "string",
-          "title": "Recipient Email Address Column",
+          "title": "Recipient Column",
           "items": {
             "enum": [],
             "type": "string"
@@ -97,21 +99,27 @@
               "label": "Re-load columns",
               "action": "load_input_table_columns",
               "autoload": ["parameters.advanced_options.email_data_table_name"]
-            }
+            },
+            "grid_columns": 6
           }
         },
         "subject_config": {
-          "title": "Subject Config",
+          "title": "Subject",
           "type": "object",
+          "format": "grid-strict",
           "propertyOrder": 3,
+          "options": {
+            "grid_columns": 12
+          },
           "properties": {
             "subject_source": {
-              "title": "Subject Source",
+              "title": "Source",
               "type": "string",
               "enum": ["from_table", "from_template_definition"],
               "options": {
                 "enum_titles": ["From Table", "From Template Definition"],
-                "tooltip": "**From Table** - specify column which contains subject template/text in Jinja2 format \n- example use case - You want to have different subject for different recipients.\n\n**From Template Definition** - paste the subject template/text into the text area field \n- example use case - You want all recipients to receive similar subject template/text"
+                "tooltip": "**From Table** - specify column which contains subject template/text in Jinja2 format \n- example use case - You want to have different subject for different recipients.\n\n**From Template Definition** - paste the subject template/text into the text area field \n- example use case - You want all recipients to receive similar subject template/text",
+                "grid_columns": 4
               },
               "propertyOrder": 1
             },
@@ -132,7 +140,8 @@
                   "action": "load_input_table_columns",
                   "autoload": ["parameters.advanced_options.email_data_table_name"]
                 },
-                "dependencies": {"subject_source": "from_table"}
+                "dependencies": {"subject_source": "from_table"},
+                "grid_columns": 8
               }
             },
             "subject_template_definition": {
@@ -143,7 +152,8 @@
               "format": "textarea",
               "options": {
                 "input_height": "100px",
-                "dependencies": {"subject_source":  "from_template_definition"}
+                "dependencies": {"subject_source":  "from_template_definition"},
+                "grid_columns": 12
               }
             },
             "validate_subject": {
@@ -153,25 +163,31 @@
                 "propertyOrder": 7,
                 "options": {
                   "async": {
-                    "label": "VALIDATE SUBJECT",
+                    "label": "Validate Subject",
                     "action": "validate_subject"
-                  }
+                  },
+                  "grid_columns": 12
                 }
               }
             }
         },
         "message_body_config": {
-          "title": "Message Body Config",
+          "title": "Message Body",
           "type": "object",
+          "format": "grid-strict",
           "propertyOrder": 4,
+          "options": {
+            "grid_columns": 12
+          },
           "properties": {
             "message_body_source": {
-              "title": "Message Body Source",
+              "title": "Source",
               "type": "string",
               "enum": ["from_table", "from_template_file", "from_template_definition"],
               "options": {
                 "enum_titles": ["From Table", "From Template File", "From Template Definition"],
-                "tooltip": "**From Table** - specify column which contains template in Jinja2 format \n- example use case - You want to have different template/message for different recipients.\n\n**From Template File** - specify input file name containing the template in Jinja2 format \n- example use case - you want each recipient to receive similar template (with differently filled placeholders), and have an orchestration which spawns this template, so that this configuration has the template updated automatically\n\n**From Template Definition** - paste the template text into the text area field \n- example use case - You want all recipients to receive similar template and it will not be changed often."
+                "tooltip": "**From Table** - specify column which contains template in Jinja2 format \n- example use case - You want to have different template/message for different recipients.\n\n**From Template File** - specify input file name containing the template in Jinja2 format \n- example use case - you want each recipient to receive similar template (with differently filled placeholders), and have an orchestration which spawns this template, so that this configuration has the template updated automatically\n\n**From Template Definition** - paste the template text into the text area field \n- example use case - You want all recipients to receive similar template and it will not be changed often.",
+                "grid_columns": 4
               },
               "propertyOrder": 1
             },
@@ -181,11 +197,14 @@
               "title": "Use HTML Template",
               "description": "HTML version is the primary displayed message, if recipients inbox doesn't support HTML, the message defaults to the plaintext version",
               "default": true,
-              "propertyOrder": 7
+              "propertyOrder": 7,
+              "options": {
+                "grid_columns": 12
+              }
             },
             "plaintext_template_column": {
               "type": "string",
-              "title": "Plaintext Message Template Column",
+              "title": "Plaintext Template Column",
               "enum": [],
               "items": {
                 "enum": [],
@@ -200,12 +219,13 @@
                   "action": "load_input_table_columns",
                   "autoload": ["parameters.advanced_options.email_data_table_name"]
                 },
-                "dependencies": {"message_body_source": "from_table"}
+                "dependencies": {"message_body_source": "from_table"},
+                "grid_columns": 8
               }
             },
             "html_template_column": {
               "type": "string",
-              "title": "HTML Message Template Column",
+              "title": "HTML Template Column",
               "enum": [],
               "items": {
                 "enum": [],
@@ -223,7 +243,8 @@
                 "dependencies": {
                   "use_html_template": true,
                   "message_body_source": "from_table"
-                }
+                },
+                "grid_columns": 12
               }
             },
             "plaintext_template_filename": {
@@ -232,7 +253,8 @@
               "default": "template.txt",
               "propertyOrder": 4,
               "options": {
-                "dependencies": {"message_body_source": "from_template_file"}
+                "dependencies": {"message_body_source": "from_template_file"},
+                "grid_columns": 8
               }
             },
             "html_template_filename": {
@@ -243,18 +265,20 @@
               "options": {
                 "dependencies": {
                   "use_html_template": true,
-                  "message_body_source": "from_template_file"}
+                  "message_body_source": "from_template_file"},
+                "grid_columns": 8
               }
             },
             "plaintext_template_definition": {
               "propertyOrder": 6,
               "type": "string",
-              "title": "Plaintext Message Body Template",
+              "title": "Plaintext Template",
               "default": "Example message body.",
               "format": "textarea",
               "options": {
                 "input_height": "100px",
-                "dependencies": {"message_body_source": "from_template_definition"}
+                "dependencies": {"message_body_source": "from_template_definition"},
+                "grid_columns": 12
               }
             },
             "validate_plaintext_template": {
@@ -264,68 +288,80 @@
               "propertyOrder": 7,
               "options": {
                 "async": {
-                  "label": "VALIDATE PLAINTEXT TEMPLATE",
+                  "label": "Validate Plaintext Template",
                   "action": "validate_plaintext_template"
-                }
+                },
+                "grid_columns": 12
               }
             },
             "html_template_definition": {
               "propertyOrder": 8,
               "type": "string",
-              "title": "HTML Message Body Template",
+              "title": "HTML Template",
               "format": "textarea",
               "default": "<h3>Example message body title</h3><p>Example message body paragraph.</p>",
               "options": {
                 "input_height": "100px",
                 "dependencies": {
                   "use_html_template": true,
-                  "message_body_source": "from_template_definition"}
+                  "message_body_source": "from_template_definition"},
+                "grid_columns": 12
               }
             },
             "validate_html_template": {
               "type": "button",
               "format": "sync-action",
-              "description": "Checks, whether all placeholders in your plaintext template are contained in the input table",
+              "description": "Checks, whether all placeholders in your HTML template are contained in the input table",
               "propertyOrder": 9,
               "options": {
                 "async": {
-                  "label": "VALIDATE HTML TEMPLATE",
+                  "label": "Validate HTML Template",
                   "action": "validate_html_template"
                 },
                 "dependencies": {
                   "use_html_template": true
-                }
+                },
+                "grid_columns": 12
               }
             }
           }
         },
         "include_attachments": {
           "type": "boolean",
-          "title": "Include Attachments",
+          "title": "Attach Data",
           "format": "checkbox",
           "default": true,
-          "propertyOrder": 5
+          "propertyOrder": 5,
+          "options": {
+            "grid_columns": 12
+          }
         },
         "attachments_config": {
-          "title": "Attachments Config",
+          "title": "Data Options",
           "type": "object",
           "format": "grid-strict",
           "propertyOrder": 6,
+          "options": {
+            "grid_columns": 12,
+            "dependencies": {
+              "include_attachments": true
+            }
+          },
           "properties": {
             "attachments_source": {
-              "title": "Attachments Source",
+              "title": "Data Source",
               "type": "string",
               "propertyOrder": 1,
               "enum": ["from_table", "single_table", "all_input_files"],
               "options": {
                 "enum_titles": ["Table Column", "Single Input Table", "All Input Files and Tables"],
                 "tooltip": "**Table Column** - each recipient gets specific attachments defined in a column (JSON list of filenames)\n- example: personalized attachments per recipient\n\n**Single Input Table** - attach a CSV sample and/or link to a selected input table\n- example: send preview of processed data or link to full table in Storage\n\n**All Input Files** - all recipients receive all non-template files in the input mapping",
-                "grid_columns": 12
+                "grid_columns": 4
               }
             },
             "attachments_column": {
               "type": "string",
-              "title": "Attachments Column",
+              "title": "Data Column",
               "enum": [],
               "description": "column expects json list of attachment filenames in input mapping, associated with specific recipients",
               "items": {
@@ -342,7 +378,7 @@
                   "autoload": ["parameters.advanced_options.email_data_table_name"]
                 },
                 "dependencies": {"attachments_source":  "from_table"},
-                "grid_columns": 12
+                "grid_columns": 8
               }
             },
             "source_table": {
@@ -364,51 +400,7 @@
                   "autoload": []
                 },
                 "dependencies": {"attachments_source": "single_table"},
-                "grid_columns": 12
-              }
-            },
-            "sort_enabled": {
-              "type": "boolean",
-              "title": "Sort Table",
-              "format": "checkbox",
-              "default": false,
-              "propertyOrder": 4,
-              "options": {
-                "dependencies": {"attachments_source": "single_table"},
-                "grid_columns": 12
-              }
-            },
-            "sort_column": {
-              "type": "string",
-              "title": "Sort by Column",
-              "items": {
-                "enum": [],
-                "type": "string"
-              },
-              "enum": [],
-              "format": "select",
-              "uniqueItems": true,
-              "propertyOrder": 5,
-              "options": {
-                "async": {
-                  "label": "Re-load columns",
-                  "action": "load_source_table_columns",
-                  "autoload": ["parameters.advanced_options.attachments_config.source_table"]
-                },
-                "dependencies": {"attachments_source": "single_table", "sort_enabled": true},
-                "grid_columns": 9
-              }
-            },
-            "sort_order": {
-              "type": "string",
-              "title": "Sort Order",
-              "enum": ["asc", "desc"],
-              "default": "asc",
-              "propertyOrder": 6,
-              "options": {
-                "enum_titles": ["Ascending", "Descending"],
-                "dependencies": {"attachments_source": "single_table", "sort_enabled": true},
-                "grid_columns": 3
+                "grid_columns": 8
               }
             },
             "include_snapshot_link": {
@@ -417,7 +409,7 @@
               "description": "Uploads the source table to File Storage and includes a download link in the email body. The snapshot file expires after 15 days.",
               "format": "checkbox",
               "default": false,
-              "propertyOrder": 7,
+              "propertyOrder": 4,
               "options": {
                 "dependencies": {"attachments_source": "single_table"},
                 "grid_columns": 12
@@ -426,10 +418,10 @@
             "include_csv_sample": {
               "type": "boolean",
               "title": "Include CSV Sample",
-              "description": "Attach a CSV file with the first N rows from the source table",
+              "description": "Include a CSV file with the first N rows from the source table",
               "format": "checkbox",
               "default": true,
-              "propertyOrder": 8,
+              "propertyOrder": 5,
               "options": {
                 "dependencies": {"attachments_source": "single_table"},
                 "grid_columns": 12
@@ -442,26 +434,70 @@
               "default": 100,
               "minimum": 1,
               "maximum": 1000,
-              "propertyOrder": 9,
+              "propertyOrder": 6,
               "options": {
                 "dependencies": {"attachments_source": "single_table", "include_csv_sample": true},
-                "grid_columns": 12
+                "grid_columns": 4
               }
             },
             "sample_attachment_filename": {
               "type": "string",
-              "title": "Sample Attachment Filename",
+              "title": "Sample Filename",
               "description": "Filename for the CSV sample. Use {table_name} placeholder.",
               "default": "{table_name}_sample.csv",
-              "propertyOrder": 10,
+              "propertyOrder": 7,
+              "options": {
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true},
+                "grid_columns": 8
+              }
+            },
+            "sort_enabled": {
+              "type": "boolean",
+              "title": "Sort Sample",
+              "format": "checkbox",
+              "default": false,
+              "propertyOrder": 8,
               "options": {
                 "dependencies": {"attachments_source": "single_table", "include_csv_sample": true},
                 "grid_columns": 12
               }
             },
+            "sort_order": {
+              "type": "string",
+              "title": "Order",
+              "enum": ["asc", "desc"],
+              "default": "asc",
+              "propertyOrder": 9,
+              "options": {
+                "enum_titles": ["Ascending", "Descending"],
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true, "sort_enabled": true},
+                "grid_columns": 4
+              }
+            },
+            "sort_column": {
+              "type": "string",
+              "title": "By Column",
+              "items": {
+                "enum": [],
+                "type": "string"
+              },
+              "enum": [],
+              "format": "select",
+              "uniqueItems": true,
+              "propertyOrder": 10,
+              "options": {
+                "async": {
+                  "label": "Re-load columns",
+                  "action": "load_source_table_columns",
+                  "autoload": ["parameters.advanced_options.attachments_config.source_table"]
+                },
+                "dependencies": {"attachments_source": "single_table", "include_csv_sample": true, "sort_enabled": true},
+                "grid_columns": 8
+              }
+            },
             "sample_info_text": {
               "type": "string",
-              "title": "Sample Info Text",
+              "title": "Sample Note",
               "description": "Text appended to email body. Use {n} for sample rows, {total} for total rows.",
               "default": "Attachment contains {n} of {total} records.",
               "format": "textarea",
@@ -479,17 +515,12 @@
               "propertyOrder": 12,
               "options": {
                 "async": {
-                  "label": "VALIDATE ATTACHMENTS",
+                  "label": "Validate Attachments",
                   "action": "validate_attachments"
                 },
                 "dependencies": {"attachments_source":  "from_table"},
                 "grid_columns": 12
               }
-            }
-          },
-          "options": {
-            "dependencies": {
-              "include_attachments": true
             }
           }
         },
@@ -500,9 +531,10 @@
           "propertyOrder": 20,
           "options": {
             "async": {
-              "label": "VALIDATE CONFIG",
+              "label": "Validate Config",
               "action": "validate_config"
-            }
+            },
+            "grid_columns": 12
           }
         }
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.2",
     "ruff>=0.15.0",
 ]
 
@@ -23,3 +24,7 @@ line-length = 120
 
 [tool.ruff.lint]
 extend-select = ["I"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/scripts/build_n_test.sh
+++ b/scripts/build_n_test.sh
@@ -2,4 +2,4 @@
 set -e
 
 ruff check .
-python -m unittest discover
+pytest

--- a/src/component.py
+++ b/src/component.py
@@ -151,6 +151,52 @@ class Component(ComponentBase):
                 "total_count": total_row_count,
             }
 
+        # Handle custom link
+        custom_link = None
+        if self.cfg.configuration_type == "advanced" and self.cfg.advanced_options.include_custom_link:
+            advanced_options = self.cfg.advanced_options
+            custom_link_url = advanced_options.custom_link_url.strip()
+
+            # Validate URL is not empty
+            if not custom_link_url or len(custom_link_url) < 5:
+                raise UserException("Custom link URL must be at least 5 characters long")
+
+            # Check if {table_id} placeholder is used
+            if "{table_id}" in custom_link_url:
+                custom_link_table = advanced_options.custom_link_table
+                if not custom_link_table:
+                    raise UserException("Custom link table must be specified when using {table_id} placeholder in URL")
+                # Resolve table_id from input mapping
+                try:
+                    table_id = next(
+                        table.source
+                        for table in self.configuration.tables_input_mapping
+                        if table.destination == custom_link_table
+                    )
+                except StopIteration:
+                    raise UserException(f"Custom link table '{custom_link_table}' not found in input mapping")
+            else:
+                table_id = ""
+
+            # Resolve placeholders
+            stack_id = self.environment_variables.stack_id
+            project_id = self.environment_variables.project_id
+            run_id = self.environment_variables.run_id
+
+            if not stack_id:
+                raise UserException("Stack ID not available for custom link URL resolution")
+            if not project_id:
+                raise UserException("Project ID not available for custom link URL resolution")
+            if not run_id:
+                raise UserException("Run ID not available for custom link URL resolution")
+
+            # Format URL with placeholders
+            resolved_url = custom_link_url.format(
+                stack=stack_id, project_id=project_id, table_id=table_id, run_id=run_id
+            )
+
+            custom_link = {"url": resolved_url, "text": advanced_options.custom_link_text}
+
         results_table = self.create_out_table_definition("results.csv", write_always=True)
         with open(results_table.full_path, "w", newline="") as output_file:
             self._results_writer = csv.DictWriter(output_file, fieldnames=RESULT_TABLE_COLUMNS)
@@ -160,6 +206,7 @@ class Component(ComponentBase):
                 email_data_table_path=email_data_table_path,
                 attachments_paths_by_filename=attachments_paths_by_filename,
                 preview_metadata=preview_metadata,
+                custom_link=custom_link,
             )
         self.write_manifest(results_table)
 
@@ -282,6 +329,7 @@ class Component(ComponentBase):
         attachments_paths_by_filename: Dict[str, str],
         email_data_table_path: Union[str, None] = None,
         preview_metadata: Union[Dict, None] = None,
+        custom_link: Union[Dict, None] = None,
     ) -> None:
         continue_on_error = self.cfg.continue_on_error
         dry_run = self.cfg.dry_run
@@ -381,6 +429,20 @@ class Component(ComponentBase):
                     # Append to HTML if present
                     if rendered_html_message:
                         rendered_html_message = f"{rendered_html_message}\n<p>{info_text_rendered}</p>"
+
+                # Append custom link to email body if present
+                if custom_link:
+                    link_text = custom_link["text"]
+                    link_url = custom_link["url"]
+
+                    # Append to plaintext (with colon)
+                    rendered_plaintext_message = f"{rendered_plaintext_message}\n{link_text}:\n{link_url}"
+
+                    # Append to HTML if present
+                    if rendered_html_message:
+                        rendered_html_message = (
+                            f'{rendered_html_message}\n<p>{link_text} <a href="{link_url}">{link_url}</a></p>'
+                        )
 
                 email_ = self._client.build_email(
                     recipient_email_address=recipient_email_address,

--- a/src/component.py
+++ b/src/component.py
@@ -112,11 +112,26 @@ class Component(ComponentBase):
             if not data_preview_table:
                 raise UserException("Data preview table must be specified for data preview mode")
 
-            # Resolve table
-            table_id, table_path = self._resolve_data_source_table_path(data_preview_table)
+            # Resolve table path and table_id from input mapping
+            table_path = self._resolve_data_source_table_path(data_preview_table)
+            table_id = next(
+                table.source
+                for table in self.configuration.tables_input_mapping
+                if table.destination == data_preview_table
+            )
 
-            # Count total rows in CSV file
-            total_row_count = self._count_csv_rows(table_path)
+            # Get total row count - prefer Storage API, fallback to local CSV
+            try:
+                storage_client = self._init_storage_client()
+                table_detail = storage_client.tables.detail(table_id)
+                total_row_count = table_detail["rowsCount"]
+                logging.info(f"Data preview: using Storage API row count ({total_row_count} rows)")
+            except Exception as e:
+                logging.warning(
+                    f"Data preview: Storage API unavailable ({str(e)}), "
+                    f"falling back to local CSV row count (may be inaccurate if input mapping uses limit/filters)"
+                )
+                total_row_count = self._count_csv_rows(table_path)
 
             # Generate preview CSV
             preview_file_path, actual_row_count = self._generate_data_preview(
@@ -227,14 +242,20 @@ class Component(ComponentBase):
     @staticmethod
     def load_email_data_table_path(in_tables, email_data_table_name):
         try:
-            table_path = next(in_table.full_path for in_table in in_tables if in_table.name == email_data_table_name)
+            table_path = next(
+                in_table.full_path for in_table in in_tables if Path(in_table.full_path).name == email_data_table_name
+            )
         except StopIteration:
             table_path = None
         return table_path
 
     @staticmethod
     def _load_attachment_tables(in_tables, table_to_exclude):
-        tables = {in_table.name: in_table.full_path for in_table in in_tables if in_table.name != table_to_exclude}
+        tables = {
+            Path(in_table.full_path).name: in_table.full_path
+            for in_table in in_tables
+            if Path(in_table.full_path).name != table_to_exclude
+        }
         return tables
 
     def _load_attachment_files(self, in_files_by_name):
@@ -495,29 +516,29 @@ class Component(ComponentBase):
             )
         return attachments_filenames
 
-    def _resolve_data_source_table_path(self, table_destination: str) -> Tuple[str, str]:
+    def _resolve_data_source_table_path(self, table_destination: str) -> str:
         """
-        Resolves data source table destination name to (table_id, local_file_path).
+        Resolves data source table destination name to local file path.
 
         Args:
-            table_destination: Table destination name from config (e.g., "email_data")
+            table_destination: Table destination name from config (e.g., "email_export.csv")
 
         Returns:
-            Tuple of (storage_table_id, local_csv_path)
+            Local CSV file path
 
         Raises:
-            UserException: If table not found in input mapping
+            UserException: If table not found in input tables
         """
+        in_tables = self.get_input_tables_definitions()
         try:
-            table_mapping = next(
-                table for table in self.configuration.tables_input_mapping if table.destination == table_destination
+            return next(
+                in_table.full_path for in_table in in_tables if Path(in_table.full_path).name == table_destination
             )
-            table_id = table_mapping.source
-            in_tables = self.get_input_tables_definitions()
-            table_path = next(in_table.full_path for in_table in in_tables if in_table.name == table_destination)
-            return table_id, table_path
         except StopIteration:
-            raise UserException(f"Data source table '{table_destination}' not found in input mapping")
+            available = [Path(t.full_path).name for t in in_tables]
+            raise UserException(
+                f"Data source table '{table_destination}' not found in input tables. Available: {available}"
+            )
 
     def _count_csv_rows(self, csv_path: str) -> int:
         """
@@ -530,7 +551,7 @@ class Component(ComponentBase):
             Number of data rows (header not counted)
         """
         with open(csv_path, encoding="utf-8") as f:
-            return sum(1 for _ in f) - 1
+            return max(0, sum(1 for _ in f) - 1)
 
     def _generate_data_preview(
         self, table_path: str, row_limit: int, filename_template: str, table_name: str

--- a/src/component.py
+++ b/src/component.py
@@ -77,6 +77,7 @@ class Component(ComponentBase):
 
     def run(self):
         self._init_configuration()
+        self._validate_run_configuration()
         self.init_client()
 
         if self.cfg.configuration_type == "advanced":
@@ -109,10 +110,7 @@ class Component(ComponentBase):
             attachments_config = self.cfg.advanced_options.attachments_config
             data_preview_table = attachments_config.data_preview_table
 
-            if not data_preview_table:
-                raise UserException("Data preview table must be specified for data preview mode")
-
-            # Resolve table path and table_id from input mapping
+            # Resolve table path and table_id from input mapping (validation already done in _validate_run_configuration)
             table_path = self._resolve_data_source_table_path(data_preview_table)
             table_id = next(
                 table.source
@@ -151,30 +149,20 @@ class Component(ComponentBase):
                 "total_count": total_row_count,
             }
 
-        # Handle custom link
+        # Handle custom link (validation already done in _validate_run_configuration)
         custom_link = None
         if self.cfg.configuration_type == "advanced" and self.cfg.advanced_options.include_custom_link:
             advanced_options = self.cfg.advanced_options
             custom_link_url = advanced_options.custom_link_url.strip()
 
-            # Validate URL is not empty
-            if not custom_link_url or len(custom_link_url) < 5:
-                raise UserException("Custom link URL must be at least 5 characters long")
-
-            # Check if {table_id} placeholder is used
+            # Resolve table_id from input mapping if {table_id} placeholder is used
             if "{table_id}" in custom_link_url:
                 custom_link_table = advanced_options.custom_link_table
-                if not custom_link_table:
-                    raise UserException("Custom link table must be specified when using {table_id} placeholder in URL")
-                # Resolve table_id from input mapping
-                try:
-                    table_id = next(
-                        table.source
-                        for table in self.configuration.tables_input_mapping
-                        if table.destination == custom_link_table
-                    )
-                except StopIteration:
-                    raise UserException(f"Custom link table '{custom_link_table}' not found in input mapping")
+                table_id = next(
+                    table.source
+                    for table in self.configuration.tables_input_mapping
+                    if table.destination == custom_link_table
+                )
             else:
                 table_id = ""
 
@@ -182,13 +170,6 @@ class Component(ComponentBase):
             stack_id = self.environment_variables.stack_id
             project_id = self.environment_variables.project_id
             run_id = self.environment_variables.run_id
-
-            if not stack_id:
-                raise UserException("Stack ID not available for custom link URL resolution")
-            if not project_id:
-                raise UserException("Project ID not available for custom link URL resolution")
-            if not run_id:
-                raise UserException("Run ID not available for custom link URL resolution")
 
             # Format URL with placeholders
             resolved_url = custom_link_url.format(
@@ -216,6 +197,59 @@ class Component(ComponentBase):
     def _init_configuration(self) -> None:
         self.validate_configuration_parameters(Configuration.get_dataclass_required_parameters())
         self.cfg: Configuration = Configuration.load_from_dict(self.configuration.parameters)
+
+    def _validate_run_configuration(self) -> None:
+        """
+        Validate configuration for data preview and custom link features.
+        Should be called after configuration is loaded and before actual work begins.
+        Skips validation for basic mode.
+        """
+        # Skip validation in basic mode
+        if self.cfg.configuration_type == "basic":
+            return
+
+        # Validate data preview configuration
+        if (
+            self.cfg.advanced_options.include_attachments
+            and self.cfg.advanced_options.attachments_config.attachments_source == "data_preview"
+        ):
+            data_preview_table = self.cfg.advanced_options.attachments_config.data_preview_table
+            if not data_preview_table:
+                raise UserException("Data preview table must be specified for data preview mode")
+
+            # Verify table exists in input tables
+            try:
+                self._resolve_data_source_table_path(data_preview_table)
+            except UserException:
+                raise  # Re-raise with original message
+
+        # Validate custom link configuration
+        if self.cfg.advanced_options.include_custom_link:
+            custom_link_url = self.cfg.advanced_options.custom_link_url.strip()
+
+            # Check if {table_id} placeholder is used
+            if "{table_id}" in custom_link_url:
+                custom_link_table = self.cfg.advanced_options.custom_link_table
+                if not custom_link_table:
+                    raise UserException("Custom link table must be specified when using {table_id} placeholder in URL")
+
+                # Verify table exists in input mapping
+                try:
+                    next(
+                        table.source
+                        for table in self.configuration.tables_input_mapping
+                        if table.destination == custom_link_table
+                    )
+                except StopIteration:
+                    raise UserException(f"Custom link table '{custom_link_table}' not found in input mapping")
+
+            # Verify required environment variables are available
+            if not self.environment_variables.stack_id:
+                raise UserException("Stack Id not available for custom link URL resolution")
+            if not self.environment_variables.project_id:
+                raise UserException("Project Id not available for custom link URL resolution")
+            if not self.environment_variables.run_id:
+                raise UserException("Run Id not available for custom link URL resolution")
 
     def _load_stack_overrides(self) -> StackOverridesParameters:
         image_parameters = self.configuration.image_parameters or {}

--- a/src/component.py
+++ b/src/component.py
@@ -139,9 +139,9 @@ class Component(ComponentBase):
                     row_limit=attachments_config.sample_row_limit,
                     filename_template=attachments_config.sample_attachment_filename,
                     table_name=source_table,
-                    sort_enabled=attachments_config.sample_sort_enabled,
-                    sort_column=attachments_config.sample_sort_column,
-                    sort_order=attachments_config.sample_sort_order,
+                    sort_enabled=attachments_config.sort_enabled,
+                    sort_column=attachments_config.sort_column,
+                    sort_order=attachments_config.sort_order,
                 )
 
                 # Override attachments with sample file only

--- a/src/component.py
+++ b/src/component.py
@@ -17,7 +17,7 @@ from keboola.component.exceptions import UserException
 from keboola.component.sync_actions import MessageType, SelectElement, ValidationResult
 
 from client import SMTPClient
-from configuration import AdvancedEmailOptions, Configuration, ConnectionConfig
+from configuration import Configuration, ConnectionConfig
 from stack_overrides import StackOverridesParameters
 
 KEY_ALLOWED_SENDER_EMAIL_ADDRESSES = "allowed_sender_email_addresses"
@@ -47,11 +47,11 @@ RESULT_TABLE_COLUMNS = (
     "error_message",
 )
 
-VALID_CONNECTION_CONFIG_MESSAGE = "✅ - Connection configuration is valid"
-VALID_SUBJECT_MESSAGE = "✅ - All subject placeholders are present in the input table"
-VALID_PLAINTEXT_TEMPLATE_MESSAGE = "✅ - All plaintext template placeholders are present in the input table"
-VALID_HTML_TEMPLATE_MESSAGE = "✅ - All HTML template placeholders are present in the input table"
-VALID_ATTACHMENTS_MESSAGE = "✅ - All attachments are present"
+VALID_CONNECTION_CONFIG_MESSAGE = "✅ Connection configuration is valid"
+VALID_SUBJECT_MESSAGE = "✅ All subject placeholders are present in the input table"
+VALID_PLAINTEXT_TEMPLATE_MESSAGE = "✅ All plaintext template placeholders are present in the input table"
+VALID_HTML_TEMPLATE_MESSAGE = "✅ All HTML template placeholders are present in the input table"
+VALID_ATTACHMENTS_MESSAGE = "✅ All attachments are present"
 
 general_error_row = {
     "status": "ERROR",
@@ -69,14 +69,13 @@ class Component(ComponentBase):
 
     def __init__(self):
         super().__init__()
-        self.cfg = Configuration
+        self._init_configuration()
         self._client: SMTPClient = None
         self._results_writer = None
         self.plaintext_template_path = None
         self.html_template_path = None
 
     def run(self):
-        self._init_configuration()
         self._validate_run_configuration()
         self.init_client()
 
@@ -100,83 +99,82 @@ class Component(ComponentBase):
         except Exception as e:
             raise UserException(f"Error loading attachments: {str(e)}")
 
-        # Handle data preview attachment mode
-        preview_metadata = None
+        # Handle single table mode: CSV sample and/or snapshot link
+        sample_metadata = None
+        snapshot_link = None
         if (
             self.cfg.configuration_type == "advanced"
             and self.cfg.advanced_options.include_attachments
-            and self.cfg.advanced_options.attachments_config.attachments_source == "data_preview"
+            and self.cfg.advanced_options.attachments_config.attachments_source == "single_table"
         ):
             attachments_config = self.cfg.advanced_options.attachments_config
-            data_preview_table = attachments_config.data_preview_table
+            source_table = attachments_config.source_table
 
             # Resolve table path and table_id from input mapping (validation already done in _validate_run_configuration)
-            table_path = self._resolve_data_source_table_path(data_preview_table)
+            table_path = self._resolve_data_source_table_path(source_table)
             table_id = next(
-                table.source
-                for table in self.configuration.tables_input_mapping
-                if table.destination == data_preview_table
+                table.source for table in self.configuration.tables_input_mapping if table.destination == source_table
             )
 
-            # Get total row count - prefer Storage API, fallback to local CSV
-            try:
-                storage_client = self._init_storage_client()
-                table_detail = storage_client.tables.detail(table_id)
-                total_row_count = table_detail["rowsCount"]
-                logging.info(f"Data preview: using Storage API row count ({total_row_count} rows)")
-            except Exception as e:
-                logging.warning(
-                    f"Data preview: Storage API unavailable ({str(e)}), "
-                    f"falling back to local CSV row count (may be inaccurate if input mapping uses limit/filters)"
+            # Handle CSV sample generation
+            if attachments_config.include_csv_sample:
+                # Get total row count - prefer Storage API, fallback to local CSV
+                try:
+                    storage_client = self._init_storage_client()
+                    table_detail = storage_client.tables.detail(table_id)
+                    total_row_count = table_detail["rowsCount"]
+                    logging.info(f"Table sample: using Storage API row count ({total_row_count} rows)")
+                except Exception as e:
+                    logging.warning(
+                        f"Table sample: Storage API unavailable ({str(e)}), "
+                        f"falling back to local CSV row count (may be inaccurate if input mapping uses limit/filters)"
+                    )
+                    total_row_count = self._count_csv_rows(table_path)
+
+                # Generate sample CSV
+                sample_file_path, actual_row_count = self._generate_table_sample(
+                    table_path=table_path,
+                    row_limit=attachments_config.sample_row_limit,
+                    filename_template=attachments_config.sample_attachment_filename,
+                    table_name=source_table,
+                    sort_enabled=attachments_config.sample_sort_enabled,
+                    sort_column=attachments_config.sample_sort_column,
+                    sort_order=attachments_config.sample_sort_order,
                 )
-                total_row_count = self._count_csv_rows(table_path)
 
-            # Generate preview CSV
-            preview_file_path, actual_row_count = self._generate_data_preview(
-                table_path=table_path,
-                row_limit=attachments_config.preview_row_limit,
-                filename_template=attachments_config.preview_attachment_filename,
-                table_name=data_preview_table,
-            )
+                # Override attachments with sample file only
+                attachments_paths_by_filename = {os.path.basename(sample_file_path): sample_file_path}
 
-            # Override attachments with preview file only
-            attachments_paths_by_filename = {os.path.basename(preview_file_path): preview_file_path}
+                # Store sample metadata for send_emails
+                sample_metadata = {
+                    "info_text": attachments_config.sample_info_text,
+                    "row_count": actual_row_count,
+                    "total_count": total_row_count,
+                }
 
-            # Store preview metadata for send_emails
-            preview_metadata = {
-                "info_text": attachments_config.preview_info_text,
-                "row_count": actual_row_count,
-                "total_count": total_row_count,
-            }
+            # Handle snapshot link
+            if attachments_config.include_snapshot_link:
+                # Resolve environment variables with fallback for local dev
+                stack_id = self.environment_variables.stack_id or "{stack}"
+                project_id = self.environment_variables.project_id or "{project_id}"
+                run_id = self.environment_variables.run_id or "{run_id}"
 
-        # Handle custom link (validation already done in _validate_run_configuration)
-        custom_link = None
-        if self.cfg.configuration_type == "advanced" and self.cfg.advanced_options.include_custom_link:
-            advanced_options = self.cfg.advanced_options
-            custom_link_url = advanced_options.custom_link_url.strip()
+                if not all(
+                    [
+                        self.environment_variables.stack_id,
+                        self.environment_variables.project_id,
+                        self.environment_variables.run_id,
+                    ]
+                ):
+                    logging.warning(
+                        "Unable to fully resolve snapshot link URL: one or more environment variables "
+                        "(stack_id, project_id, run_id) not available. Link will contain unresolved placeholders."
+                    )
 
-            # Resolve table_id from input mapping if {table_id} placeholder is used
-            if "{table_id}" in custom_link_url:
-                custom_link_table = advanced_options.custom_link_table
-                table_id = next(
-                    table.source
-                    for table in self.configuration.tables_input_mapping
-                    if table.destination == custom_link_table
-                )
-            else:
-                table_id = ""
+                # Hardcoded URL pattern for Keboola table preview
+                resolved_url = f"https://{stack_id}/admin/projects/{project_id}/table-preview/{table_id}?context=%2Fqueue%2F{run_id}"
 
-            # Resolve placeholders
-            stack_id = self.environment_variables.stack_id
-            project_id = self.environment_variables.project_id
-            run_id = self.environment_variables.run_id
-
-            # Format URL with placeholders
-            resolved_url = custom_link_url.format(
-                stack=stack_id, project_id=project_id, table_id=table_id, run_id=run_id
-            )
-
-            custom_link = {"url": resolved_url, "text": advanced_options.custom_link_text}
+                snapshot_link = {"url": resolved_url, "text": "View table snapshot in Storage"}
 
         results_table = self.create_out_table_definition("results.csv", write_always=True)
         with open(results_table.full_path, "w", newline="") as output_file:
@@ -186,8 +184,8 @@ class Component(ComponentBase):
             self.send_emails(
                 email_data_table_path=email_data_table_path,
                 attachments_paths_by_filename=attachments_paths_by_filename,
-                preview_metadata=preview_metadata,
-                custom_link=custom_link,
+                sample_metadata=sample_metadata,
+                snapshot_link=snapshot_link,
             )
         self.write_manifest(results_table)
 
@@ -200,7 +198,7 @@ class Component(ComponentBase):
 
     def _validate_run_configuration(self) -> None:
         """
-        Validate configuration for data preview and custom link features.
+        Validate configuration for single table mode (CSV sample and snapshot link features).
         Should be called after configuration is loaded and before actual work begins.
         Skips validation for basic mode.
         """
@@ -208,48 +206,38 @@ class Component(ComponentBase):
         if self.cfg.configuration_type == "basic":
             return
 
-        # Validate data preview configuration
+        # Validate attachment source is a recognized value (early check)
+        if self.cfg.advanced_options.include_attachments:
+            attachments_source = self.cfg.advanced_options.attachments_config.attachments_source
+            if attachments_source not in ("from_table", "single_table", "all_input_files"):
+                raise UserException(
+                    f"Unknown attachment source: '{attachments_source}'. "
+                    f"Valid options: 'from_table', 'single_table', 'all_input_files'"
+                )
+
+        # Validate single table mode configuration
         if (
             self.cfg.advanced_options.include_attachments
-            and self.cfg.advanced_options.attachments_config.attachments_source == "data_preview"
+            and self.cfg.advanced_options.attachments_config.attachments_source == "single_table"
         ):
-            data_preview_table = self.cfg.advanced_options.attachments_config.data_preview_table
-            if not data_preview_table:
-                raise UserException("Data preview table must be specified for data preview mode")
+            attachments_config = self.cfg.advanced_options.attachments_config
+            source_table = attachments_config.source_table
+
+            # Source table must be specified
+            if not source_table:
+                raise UserException("Source table must be specified for single table mode")
 
             # Verify table exists in input tables
             try:
-                self._resolve_data_source_table_path(data_preview_table)
+                self._resolve_data_source_table_path(source_table)
             except UserException:
                 raise  # Re-raise with original message
 
-        # Validate custom link configuration
-        if self.cfg.advanced_options.include_custom_link:
-            custom_link_url = self.cfg.advanced_options.custom_link_url.strip()
-
-            # Check if {table_id} placeholder is used
-            if "{table_id}" in custom_link_url:
-                custom_link_table = self.cfg.advanced_options.custom_link_table
-                if not custom_link_table:
-                    raise UserException("Custom link table must be specified when using {table_id} placeholder in URL")
-
-                # Verify table exists in input mapping
-                try:
-                    next(
-                        table.source
-                        for table in self.configuration.tables_input_mapping
-                        if table.destination == custom_link_table
-                    )
-                except StopIteration:
-                    raise UserException(f"Custom link table '{custom_link_table}' not found in input mapping")
-
-            # Verify required environment variables are available
-            if not self.environment_variables.stack_id:
-                raise UserException("Stack Id not available for custom link URL resolution")
-            if not self.environment_variables.project_id:
-                raise UserException("Project Id not available for custom link URL resolution")
-            if not self.environment_variables.run_id:
-                raise UserException("Run Id not available for custom link URL resolution")
+            # At least one feature (CSV sample or snapshot link) must be enabled
+            if not attachments_config.include_csv_sample and not attachments_config.include_snapshot_link:
+                raise UserException(
+                    "At least one option must be enabled: 'Include CSV Sample' or 'Include Link to Table Snapshot'"
+                )
 
     def _load_stack_overrides(self) -> StackOverridesParameters:
         image_parameters = self.configuration.image_parameters or {}
@@ -362,8 +350,8 @@ class Component(ComponentBase):
         self,
         attachments_paths_by_filename: Dict[str, str],
         email_data_table_path: Union[str, None] = None,
-        preview_metadata: Union[Dict, None] = None,
-        custom_link: Union[Dict, None] = None,
+        sample_metadata: Union[Dict, None] = None,
+        snapshot_link: Union[Dict, None] = None,
     ) -> None:
         continue_on_error = self.cfg.continue_on_error
         dry_run = self.cfg.dry_run
@@ -443,18 +431,18 @@ class Component(ComponentBase):
                     custom_attachments_paths_by_filename = attachments_paths_by_filename
                     if self.cfg.advanced_options.include_attachments and not self._client.disable_attachments:
                         # Only "from_table" mode needs per-row attachment loading from CSV column;
-                        # other modes (all_input_files, data_preview) use the same attachments for all recipients
+                        # other modes (all_input_files, single_table) use the same attachments for all recipients
                         if attachments_config.attachments_source == "from_table":
                             custom_attachments_paths_by_filename = {
                                 attachment_filename: attachments_paths_by_filename[attachment_filename]
                                 for attachment_filename in json.loads(row[attachments_column])
                             }
 
-                # Append preview info text to email body if present
-                if preview_metadata and not self._client.disable_attachments:
-                    info_text_rendered = preview_metadata["info_text"].format(
-                        n=preview_metadata["row_count"],
-                        total=preview_metadata["total_count"],
+                # Append sample info text to email body if present
+                if sample_metadata and not self._client.disable_attachments:
+                    info_text_rendered = sample_metadata["info_text"].format(
+                        n=sample_metadata["row_count"],
+                        total=sample_metadata["total_count"],
                     )
 
                     # Append to plaintext
@@ -465,9 +453,9 @@ class Component(ComponentBase):
                         rendered_html_message = f"{rendered_html_message}\n<p>{info_text_rendered}</p>"
 
                 # Append custom link to email body if present
-                if custom_link:
-                    link_text = custom_link["text"]
-                    link_url = custom_link["url"]
+                if snapshot_link:
+                    link_text = snapshot_link["text"]
+                    link_url = snapshot_link["url"]
 
                     # Append to plaintext (with colon)
                     rendered_plaintext_message = f"{rendered_plaintext_message}\n{link_text}:\n{link_url}"
@@ -595,7 +583,7 @@ class Component(ComponentBase):
         missing_columns = set(template_placeholders) - set(columns)
         if missing_columns:
             if not continue_on_error:
-                raise UserException("❌ - Missing columns: " + ", ".join(missing_columns))
+                raise UserException("❌ Missing columns: " + ", ".join(missing_columns))
 
     def _get_attachments_filenames_from_table(self, in_table_path: str) -> Set[str]:
         attachments_filenames = set()
@@ -649,41 +637,57 @@ class Component(ComponentBase):
         with open(csv_path, encoding="utf-8") as f:
             return max(0, sum(1 for _ in f) - 1)
 
-    def _generate_data_preview(
-        self, table_path: str, row_limit: int, filename_template: str, table_name: str
+    def _generate_table_sample(
+        self,
+        table_path: str,
+        row_limit: int,
+        filename_template: str,
+        table_name: str,
+        sort_enabled: bool = False,
+        sort_column: Union[str, None] = None,
+        sort_order: str = "asc",
     ) -> Tuple[str, int]:
         """
-        Generates a CSV preview file with first N rows.
+        Generates a CSV sample file with first N rows, optionally sorted.
 
         Args:
             table_path: Path to source CSV file
             row_limit: Maximum number of rows to include
             filename_template: Filename template with {table_name} placeholder
             table_name: Table name for filename substitution
+            sort_enabled: Whether sorting is enabled
+            sort_column: Column name to sort by (optional)
+            sort_order: Sort order - "asc" or "desc" (default: "asc")
 
         Returns:
-            Tuple of (preview_file_path, actual_row_count)
+            Tuple of (sample_file_path, actual_row_count)
         """
         filename = filename_template.replace("{table_name}", table_name)
-        preview_path = os.path.join(self.data_folder_path, filename)
+        sample_path = os.path.join(self.data_folder_path, filename)
 
         with open(table_path, encoding="utf-8") as source:
-            reader = csv.reader(source)
-            header = next(reader, None)
+            reader = csv.DictReader(source)
+            header = reader.fieldnames
 
-            with open(preview_path, "w", encoding="utf-8", newline="") as dest:
-                writer = csv.writer(dest)
-                if header:
-                    writer.writerow(header)
+            # Read rows up to limit
+            rows = []
+            for i, row in enumerate(reader):
+                if i >= row_limit:
+                    break
+                rows.append(row)
 
-                row_count = 0
-                for row in reader:
-                    if row_count >= row_limit:
-                        break
-                    writer.writerow(row)
-                    row_count += 1
+            # Sort if enabled and column specified and exists in header
+            if sort_enabled and sort_column and sort_column in header:
+                reverse = sort_order == "desc"
+                rows.sort(key=lambda r: r.get(sort_column, ""), reverse=reverse)
 
-        return preview_path, row_count
+            # Write to sample file
+            with open(sample_path, "w", encoding="utf-8", newline="") as dest:
+                writer = csv.DictWriter(dest, fieldnames=header)
+                writer.writeheader()
+                writer.writerows(rows)
+
+        return sample_path, len(rows)
 
     def _get_missing_columns_from_table(self, reader: csv.DictReader, column: str) -> Set[str]:
         unique_placeholders = set()
@@ -700,7 +704,7 @@ class Component(ComponentBase):
         template_column = self.cfg.advanced_options.message_body_config[key_template_column]
         missing_columns = self._get_missing_columns_from_table(reader, template_column)
         if missing_columns:
-            message = "❌ - Missing columns: " + ", ".join(missing_columns)
+            message = "❌ Missing columns: " + ", ".join(missing_columns)
             message_type = MessageType.DANGER
         return ValidationResult(message, message_type)
 
@@ -776,7 +780,6 @@ class Component(ComponentBase):
             return []
 
     def _validate_template(self, plaintext: bool = True) -> ValidationResult:
-        self._init_configuration()
         valid_message = VALID_PLAINTEXT_TEMPLATE_MESSAGE if plaintext else VALID_HTML_TEMPLATE_MESSAGE
         if self.cfg.advanced_options.message_body_config.message_body_source == "from_table":
             table_name = self.cfg.advanced_options.email_data_table_name
@@ -800,7 +803,7 @@ class Component(ComponentBase):
             # If loading failed, we can't validate - return error (strict)
             if isinstance(columns, ValidationResult):
                 return ValidationResult(
-                    "❌ - Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
+                    "❌ Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
                 )
 
             # Validate placeholders against columns
@@ -817,9 +820,9 @@ class Component(ComponentBase):
         connection_config = ConnectionConfig.load_from_dict(self.configuration.parameters["connection_config"])
         try:
             self.init_client(connection_config=connection_config)
-            return ValidationResult("✅ - Connection established successfully", MessageType.SUCCESS)
+            return ValidationResult("✅ Connection established successfully", MessageType.SUCCESS)
         except Exception as e:
-            return ValidationResult(f"❌ - Connection couldn't be established. Error: {e}", MessageType.DANGER)
+            return ValidationResult(f"❌ Connection couldn't be established. Error: {e}", MessageType.DANGER)
 
     @sync_action("testConnection")
     def test_smtp_server_connection(self) -> ValidationResult:
@@ -827,15 +830,12 @@ class Component(ComponentBase):
 
     @sync_action("load_input_table_selection")
     def load_input_table_selection(self) -> List[SelectElement]:
-        self._init_configuration()
         return [SelectElement(table.destination) for table in self.configuration.tables_input_mapping]
 
-    def load_input_table_columns_(self) -> Union[List[str], ValidationResult]:
-        advanced_options = AdvancedEmailOptions.load_from_dict(self.configuration.parameters["advanced_options"])
-        table_name = advanced_options.email_data_table_name
+    def _load_table_columns(self, table_name: str | None, field_label: str) -> list[str] | ValidationResult:
+        """Fetch columns from a table via Storage API. Used by sync actions."""
         if table_name is None:
-            message = "You must specify `Email Data Table Name` before loading columns"
-            return ValidationResult(message, MessageType.DANGER)
+            return ValidationResult(f"You must specify `{field_label}` before loading columns", MessageType.DANGER)
         try:
             table_id = next(
                 table.source for table in self.configuration.tables_input_mapping if table.destination == table_name
@@ -853,14 +853,20 @@ class Component(ComponentBase):
             return ValidationResult("Couldn't fetch columns", MessageType.DANGER)
 
     @sync_action("load_input_table_columns")
-    def load_input_table_columns(self) -> List[SelectElement]:
-        columns = self.load_input_table_columns_()
+    def load_input_table_columns(self) -> list[SelectElement]:
+        columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
+        if isinstance(columns, ValidationResult):
+            return columns
+        return [SelectElement(column) for column in columns]
+
+    @sync_action("load_source_table_columns")
+    def load_source_table_columns(self) -> list[SelectElement]:
+        columns = self._load_table_columns(self.cfg.advanced_options.attachments_config.source_table, "Source Table")
         if isinstance(columns, ValidationResult):
             return columns
         return [SelectElement(column) for column in columns]
 
     def validate_subject_(self) -> ValidationResult:
-        self._init_configuration()
         subject_config = self.cfg.advanced_options.subject_config
         if subject_config.subject_source == "from_table":
             subject_column = subject_config.subject_column
@@ -870,7 +876,7 @@ class Component(ComponentBase):
                 reader = csv.DictReader(in_table)
                 missing_columns = self._get_missing_columns_from_table(reader, subject_column)
                 if missing_columns:
-                    message = "❌ - Missing columns: " + ", ".join(missing_columns)
+                    message = "❌ Missing columns: " + ", ".join(missing_columns)
                     return ValidationResult(message, MessageType.DANGER)
                 return ValidationResult(VALID_SUBJECT_MESSAGE, MessageType.SUCCESS)
         else:
@@ -889,7 +895,7 @@ class Component(ComponentBase):
             # If loading failed, we can't validate - return error (strict)
             if isinstance(columns, ValidationResult):
                 return ValidationResult(
-                    "❌ - Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
+                    "❌ Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
                 )
 
             # Validate placeholders against columns
@@ -918,10 +924,9 @@ class Component(ComponentBase):
         return self.validate_html_template_()
 
     def validate_attachments_(self) -> ValidationResult:
-        self._init_configuration()
         message = VALID_ATTACHMENTS_MESSAGE
         try:
-            if self.cfg.advanced_options.attachments_config.attachments_source != "all_input_files":
+            if self.cfg.advanced_options.attachments_config.attachments_source == "from_table":
                 table_name = self.cfg.advanced_options.email_data_table_name
                 in_table_path = self._return_table_path(table_name)
                 expected_input_filenames = self._get_attachments_filenames_from_table(in_table_path)
@@ -929,9 +934,9 @@ class Component(ComponentBase):
                 input_tables = set([table.destination for table in self.configuration.tables_input_mapping])
                 missing_attachments = expected_input_filenames - input_filenames - input_tables
                 if missing_attachments:
-                    message = "❌ - Missing attachments: " + ", ".join(missing_attachments)
+                    message = "❌ Missing attachments: " + ", ".join(missing_attachments)
         except Exception as e:
-            message = f"❌ - Couldn't validate attachments. Error: {e}"
+            message = f"❌ Couldn't validate attachments. Error: {e}"
         message_type = MessageType.SUCCESS if message == VALID_ATTACHMENTS_MESSAGE else MessageType.DANGER
         return ValidationResult(message, message_type)
 
@@ -939,9 +944,54 @@ class Component(ComponentBase):
     def validate_attachments(self) -> ValidationResult:
         return self.validate_attachments_()
 
+    def validate_single_table_(self) -> ValidationResult:
+        """
+        Validate single table mode configuration (CSV sample and snapshot link features).
+
+        Note: This is a helper method (trailing underscore) called from validate_config() sync action.
+        The underscore suffix prevents the @sync_action decorator from interfering when called from
+        another sync action - decorated methods would redirect stdout, write JSON, and potentially exit(),
+        which would hijack the caller's output handling.
+
+        Returns ValidationResult with aggregated error messages (all errors at once, not fail-fast).
+        """
+        errors = []
+
+        attachments_config = self.cfg.advanced_options.attachments_config
+        source_table = attachments_config.source_table
+
+        # Check 1: Source table must be specified
+        if not source_table:
+            errors.append("❌ Source table must be specified for single table mode")
+        else:
+            # Check 2: Source table must exist in input tables (use tables_input_mapping for sync actions)
+            available_tables = [table.destination for table in self.configuration.tables_input_mapping]
+            if source_table not in available_tables:
+                errors.append(
+                    f"❌ Source table '{source_table}' not found in input tables. Available: {available_tables}"
+                )
+
+        # Check 3: At least one toggle must be enabled
+        if not attachments_config.include_csv_sample and not attachments_config.include_snapshot_link:
+            errors.append(
+                "❌ At least one option must be enabled: 'Include CSV Sample' or 'Include Link to Table Snapshot'"
+            )
+
+        if errors:
+            message = "\n\n".join(errors)
+            message_type = MessageType.ERROR
+        else:
+            message = "✅ Single table configuration is valid"
+            message_type = MessageType.SUCCESS
+
+        return ValidationResult(message, message_type)
+
+    @sync_action("validate_single_table")
+    def validate_single_table(self) -> ValidationResult:
+        return self.validate_single_table_()
+
     @sync_action("validate_config")
     def validate_config(self) -> ValidationResult:
-        self._init_configuration()
         # TODO: once sys.stdout is None handling is released, remove helper methods and use other sync actions directly
         validation_methods = [
             self.test_smtp_server_connection_,
@@ -953,12 +1003,21 @@ class Component(ComponentBase):
 
         image_parameters = self.configuration.image_parameters or {}
         disable_attachments = image_parameters.get(KEY_DISABLE_ATTACHMENTS, False)
-        if (
-            self.cfg.advanced_options.include_attachments
-            and not disable_attachments
-            and self.cfg.advanced_options.attachments_config.attachments_source != "data_preview"
-        ):
-            validation_methods.append(self.validate_attachments_)
+        if self.cfg.advanced_options.include_attachments and not disable_attachments:
+            attachments_source = self.cfg.advanced_options.attachments_config.attachments_source
+
+            # Early return for unrecognized attachment source values (e.g., legacy configs)
+            if attachments_source not in ("from_table", "single_table", "all_input_files"):
+                return ValidationResult(
+                    f"❌ Unknown attachment source: '{attachments_source}'. "
+                    f"Valid options: 'from_table', 'single_table', 'all_input_files'",
+                    MessageType.DANGER,
+                )
+
+            if attachments_source == "single_table":
+                validation_methods.append(self.validate_single_table_)
+            elif attachments_source == "from_table":
+                validation_methods.append(self.validate_attachments_)
 
         messages = [validation_method().message for validation_method in validation_methods]
 

--- a/src/component.py
+++ b/src/component.py
@@ -116,11 +116,13 @@ class Component(ComponentBase):
                 table.source for table in self.configuration.tables_input_mapping if table.destination == source_table
             )
 
+            # Initialize storage client once for both CSV sample and snapshot link
+            storage_client = self._init_storage_client()
+
             # Handle CSV sample generation
             if attachments_config.include_csv_sample:
                 # Get total row count - prefer Storage API, fallback to local CSV
                 try:
-                    storage_client = self._init_storage_client()
                     table_detail = storage_client.tables.detail(table_id)
                     total_row_count = table_detail["rowsCount"]
                     logging.info(f"Table sample: using Storage API row count ({total_row_count} rows)")
@@ -152,29 +154,30 @@ class Component(ComponentBase):
                     "total_count": total_row_count,
                 }
 
-            # Handle snapshot link
+            # Handle snapshot link - upload table to File Storage
             if attachments_config.include_snapshot_link:
-                # Resolve environment variables with fallback for local dev
-                stack_id = self.environment_variables.stack_id or "{stack}"
-                project_id = self.environment_variables.project_id or "{project_id}"
-                run_id = self.environment_variables.run_id or "{run_id}"
+                try:
+                    run_id = self.environment_variables.run_id or "unknown"
 
-                if not all(
-                    [
-                        self.environment_variables.stack_id,
-                        self.environment_variables.project_id,
-                        self.environment_variables.run_id,
-                    ]
-                ):
-                    logging.warning(
-                        "Unable to fully resolve snapshot link URL: one or more environment variables "
-                        "(stack_id, project_id, run_id) not available. Link will contain unresolved placeholders."
+                    file_id = storage_client.files.upload_file(
+                        file_path=table_path,
+                        tags=["data-snapshot", f"table:{table_id}", f"runId:{run_id}"],
+                        is_permanent=False,
+                        compress=True,
                     )
 
-                # Hardcoded URL pattern for Keboola table preview
-                resolved_url = f"https://{stack_id}/admin/projects/{project_id}/table-preview/{table_id}?context=%2Fqueue%2F{run_id}"
+                    stack_id = self.environment_variables.stack_id or "STACK_ID"
+                    project_id = self.environment_variables.project_id or "PROJECT_ID"
+                    resolved_url = f"https://{stack_id}/admin/projects/{project_id}/storage/files?q=id%3A{file_id}"
+                    snapshot_link = {"url": resolved_url, "text": "View table data snapshot in Storage"}
 
-                snapshot_link = {"url": resolved_url, "text": "View table snapshot in Storage"}
+                    logging.info(f"Uploaded data snapshot to File Storage (file_id={file_id}, table={table_id})")
+                except Exception as e:
+                    error_msg = f"Failed to upload data snapshot to File Storage: {e}"
+                    if self.cfg.continue_on_error:
+                        logging.warning(f"{error_msg}. Snapshot link will not be included.")
+                    else:
+                        raise UserException(error_msg)
 
         results_table = self.create_out_table_definition("results.csv", write_always=True)
         with open(results_table.full_path, "w", newline="") as output_file:
@@ -456,14 +459,18 @@ class Component(ComponentBase):
                 if snapshot_link:
                     link_text = snapshot_link["text"]
                     link_url = snapshot_link["url"]
+                    expiry_note = "(snapshot expires after 15 days)"
 
-                    # Append to plaintext (with colon)
-                    rendered_plaintext_message = f"{rendered_plaintext_message}\n{link_text}:\n{link_url}"
+                    # Append to plaintext (with colon and expiry note)
+                    rendered_plaintext_message = (
+                        f"{rendered_plaintext_message}\n{link_text}:\n{link_url}\n{expiry_note}"
+                    )
 
-                    # Append to HTML if present
+                    # Append to HTML if present (with expiry note)
                     if rendered_html_message:
                         rendered_html_message = (
-                            f'{rendered_html_message}\n<p>{link_text} <a href="{link_url}">{link_url}</a></p>'
+                            f'{rendered_html_message}\n<p>{link_text} <a href="{link_url}">{link_url}</a><br>'
+                            f"<small>{expiry_note}</small></p>"
                         )
 
                 email_ = self._client.build_email(

--- a/src/component.py
+++ b/src/component.py
@@ -99,13 +99,52 @@ class Component(ComponentBase):
         except Exception as e:
             raise UserException(f"Error loading attachments: {str(e)}")
 
+        # Handle data preview attachment mode
+        preview_metadata = None
+        if (
+            self.cfg.configuration_type == "advanced"
+            and self.cfg.advanced_options.include_attachments
+            and self.cfg.advanced_options.attachments_config.attachments_source == "data_preview"
+        ):
+            attachments_config = self.cfg.advanced_options.attachments_config
+            data_preview_table = attachments_config.data_preview_table
+
+            if not data_preview_table:
+                raise UserException("Data preview table must be specified for data preview mode")
+
+            # Resolve table
+            table_id, table_path = self._resolve_data_source_table_path(data_preview_table)
+
+            # Count total rows in CSV file
+            total_row_count = self._count_csv_rows(table_path)
+
+            # Generate preview CSV
+            preview_file_path, actual_row_count = self._generate_data_preview(
+                table_path=table_path,
+                row_limit=attachments_config.preview_row_limit,
+                filename_template=attachments_config.preview_attachment_filename,
+                table_name=data_preview_table,
+            )
+
+            # Override attachments with preview file only
+            attachments_paths_by_filename = {os.path.basename(preview_file_path): preview_file_path}
+
+            # Store preview metadata for send_emails
+            preview_metadata = {
+                "info_text": attachments_config.preview_info_text,
+                "row_count": actual_row_count,
+                "total_count": total_row_count,
+            }
+
         results_table = self.create_out_table_definition("results.csv", write_always=True)
         with open(results_table.full_path, "w", newline="") as output_file:
             self._results_writer = csv.DictWriter(output_file, fieldnames=RESULT_TABLE_COLUMNS)
             self._results_writer.writeheader()
             self._results_writer.errors = False
             self.send_emails(
-                email_data_table_path=email_data_table_path, attachments_paths_by_filename=attachments_paths_by_filename
+                email_data_table_path=email_data_table_path,
+                attachments_paths_by_filename=attachments_paths_by_filename,
+                preview_metadata=preview_metadata,
             )
         self.write_manifest(results_table)
 
@@ -218,7 +257,10 @@ class Component(ComponentBase):
         return {**table_attachments_paths_by_filename, **file_attachments_paths_by_filename}
 
     def send_emails(
-        self, attachments_paths_by_filename: Dict[str, str], email_data_table_path: Union[str, None] = None
+        self,
+        attachments_paths_by_filename: Dict[str, str],
+        email_data_table_path: Union[str, None] = None,
+        preview_metadata: Union[Dict, None] = None,
     ) -> None:
         continue_on_error = self.cfg.continue_on_error
         dry_run = self.cfg.dry_run
@@ -232,7 +274,6 @@ class Component(ComponentBase):
         subject_column = None
         plaintext_template_column = None
         html_template_column = None
-        all_attachments = attachments_config.attachments_source == "all_input_files"
         attachments_column = attachments_config.attachments_column
 
         if email_data_table_path:
@@ -298,11 +339,27 @@ class Component(ComponentBase):
 
                     custom_attachments_paths_by_filename = attachments_paths_by_filename
                     if self.cfg.advanced_options.include_attachments and not self._client.disable_attachments:
-                        if not all_attachments:
+                        # Only "from_table" mode needs per-row attachment loading from CSV column;
+                        # other modes (all_input_files, data_preview) use the same attachments for all recipients
+                        if attachments_config.attachments_source == "from_table":
                             custom_attachments_paths_by_filename = {
                                 attachment_filename: attachments_paths_by_filename[attachment_filename]
                                 for attachment_filename in json.loads(row[attachments_column])
                             }
+
+                # Append preview info text to email body if present
+                if preview_metadata and not self._client.disable_attachments:
+                    info_text_rendered = preview_metadata["info_text"].format(
+                        n=preview_metadata["row_count"],
+                        total=preview_metadata["total_count"],
+                    )
+
+                    # Append to plaintext
+                    rendered_plaintext_message = f"{rendered_plaintext_message}\n{info_text_rendered}"
+
+                    # Append to HTML if present
+                    if rendered_html_message:
+                        rendered_html_message = f"{rendered_html_message}\n<p>{info_text_rendered}</p>"
 
                 email_ = self._client.build_email(
                     recipient_email_address=recipient_email_address,
@@ -438,6 +495,79 @@ class Component(ComponentBase):
             )
         return attachments_filenames
 
+    def _resolve_data_source_table_path(self, table_destination: str) -> Tuple[str, str]:
+        """
+        Resolves data source table destination name to (table_id, local_file_path).
+
+        Args:
+            table_destination: Table destination name from config (e.g., "email_data")
+
+        Returns:
+            Tuple of (storage_table_id, local_csv_path)
+
+        Raises:
+            UserException: If table not found in input mapping
+        """
+        try:
+            table_mapping = next(
+                table for table in self.configuration.tables_input_mapping if table.destination == table_destination
+            )
+            table_id = table_mapping.source
+            in_tables = self.get_input_tables_definitions()
+            table_path = next(in_table.full_path for in_table in in_tables if in_table.name == table_destination)
+            return table_id, table_path
+        except StopIteration:
+            raise UserException(f"Data source table '{table_destination}' not found in input mapping")
+
+    def _count_csv_rows(self, csv_path: str) -> int:
+        """
+        Counts data rows in CSV file (excluding header).
+
+        Args:
+            csv_path: Path to CSV file
+
+        Returns:
+            Number of data rows (header not counted)
+        """
+        with open(csv_path, encoding="utf-8") as f:
+            return sum(1 for _ in f) - 1
+
+    def _generate_data_preview(
+        self, table_path: str, row_limit: int, filename_template: str, table_name: str
+    ) -> Tuple[str, int]:
+        """
+        Generates a CSV preview file with first N rows.
+
+        Args:
+            table_path: Path to source CSV file
+            row_limit: Maximum number of rows to include
+            filename_template: Filename template with {table_name} placeholder
+            table_name: Table name for filename substitution
+
+        Returns:
+            Tuple of (preview_file_path, actual_row_count)
+        """
+        filename = filename_template.replace("{table_name}", table_name)
+        preview_path = os.path.join(self.data_folder_path, filename)
+
+        with open(table_path, encoding="utf-8") as source:
+            reader = csv.reader(source)
+            header = next(reader, None)
+
+            with open(preview_path, "w", encoding="utf-8", newline="") as dest:
+                writer = csv.writer(dest)
+                if header:
+                    writer.writerow(header)
+
+                row_count = 0
+                for row in reader:
+                    if row_count >= row_limit:
+                        break
+                    writer.writerow(row)
+                    row_count += 1
+
+        return preview_path, row_count
+
     def _get_missing_columns_from_table(self, reader: csv.DictReader, column: str) -> Set[str]:
         unique_placeholders = set()
         for row in reader:
@@ -539,8 +669,25 @@ class Component(ComponentBase):
                 return self._validate_templates_from_table(reader, plaintext)
         else:
             template_text = self._read_template_text(plaintext)
+
+            # Parse placeholders first
+            template_placeholders = self._parse_template_placeholders(template_text)
+
+            # If no placeholders, validation passes immediately
+            if not template_placeholders:
+                return ValidationResult(valid_message, MessageType.SUCCESS)
+
+            # Load columns only if we have placeholders to validate
+            columns = self.load_input_table_columns_()
+
+            # If loading failed, we can't validate - return error (strict)
+            if isinstance(columns, ValidationResult):
+                return ValidationResult(
+                    "❌ - Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
+                )
+
+            # Validate placeholders against columns
             try:
-                columns = self.load_input_table_columns_()
                 self._validate_template_text(template_text, columns)
                 return ValidationResult(valid_message, MessageType.SUCCESS)
             except UserException as e:
@@ -598,7 +745,6 @@ class Component(ComponentBase):
     def validate_subject_(self) -> ValidationResult:
         self._init_configuration()
         subject_config = self.cfg.advanced_options.subject_config
-        message = VALID_SUBJECT_MESSAGE
         if subject_config.subject_source == "from_table":
             subject_column = subject_config.subject_column
             table_name = self.cfg.advanced_options.email_data_table_name
@@ -608,15 +754,33 @@ class Component(ComponentBase):
                 missing_columns = self._get_missing_columns_from_table(reader, subject_column)
                 if missing_columns:
                     message = "❌ - Missing columns: " + ", ".join(missing_columns)
+                    return ValidationResult(message, MessageType.DANGER)
+                return ValidationResult(VALID_SUBJECT_MESSAGE, MessageType.SUCCESS)
         else:
             subject_template_text = subject_config.subject_template_definition
+
+            # Parse placeholders first
+            template_placeholders = self._parse_template_placeholders(subject_template_text)
+
+            # If no placeholders, validation passes immediately
+            if not template_placeholders:
+                return ValidationResult(VALID_SUBJECT_MESSAGE, MessageType.SUCCESS)
+
+            # Load columns only if we have placeholders to validate
             columns = self.load_input_table_columns_()
+
+            # If loading failed, we can't validate - return error (strict)
+            if isinstance(columns, ValidationResult):
+                return ValidationResult(
+                    "❌ - Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
+                )
+
+            # Validate placeholders against columns
             try:
                 self._validate_template_text(subject_template_text, columns)
-            except Exception as e:
-                message = str(e)
-        message_type = MessageType.SUCCESS if message == VALID_SUBJECT_MESSAGE else MessageType.DANGER
-        return ValidationResult(message, message_type)
+                return ValidationResult(VALID_SUBJECT_MESSAGE, MessageType.SUCCESS)
+            except UserException as e:
+                return ValidationResult(str(e), MessageType.DANGER)
 
     @sync_action("validate_subject")
     def validate_subject(self) -> ValidationResult:
@@ -672,7 +836,11 @@ class Component(ComponentBase):
 
         image_parameters = self.configuration.image_parameters or {}
         disable_attachments = image_parameters.get(KEY_DISABLE_ATTACHMENTS, False)
-        if self.cfg.advanced_options.include_attachments and not disable_attachments:
+        if (
+            self.cfg.advanced_options.include_attachments
+            and not disable_attachments
+            and self.cfg.advanced_options.attachments_config.attachments_source != "data_preview"
+        ):
             validation_methods.append(self.validate_attachments_)
 
         messages = [validation_method().message for validation_method in validation_methods]

--- a/src/component.py
+++ b/src/component.py
@@ -805,7 +805,7 @@ class Component(ComponentBase):
                 return ValidationResult(valid_message, MessageType.SUCCESS)
 
             # Load columns only if we have placeholders to validate
-            columns = self.load_input_table_columns_()
+            columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
 
             # If loading failed, we can't validate - return error (strict)
             if isinstance(columns, ValidationResult):
@@ -897,7 +897,7 @@ class Component(ComponentBase):
                 return ValidationResult(VALID_SUBJECT_MESSAGE, MessageType.SUCCESS)
 
             # Load columns only if we have placeholders to validate
-            columns = self.load_input_table_columns_()
+            columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
 
             # If loading failed, we can't validate - return error (strict)
             if isinstance(columns, ValidationResult):

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -140,15 +140,22 @@ class AttachmentsConfig(ConfigurationBase):
     attachments_source:
     "all_input_files"
     "from_table" -> "attachments_column"
-    "data_preview" -> "data_preview_table", "preview_row_limit", "preview_attachment_filename", "preview_info_text"
+    "single_table" -> "source_table", "include_csv_sample", "sample_row_limit", "sample_attachment_filename",
+                      "sample_info_text", "sample_sort_enabled", "sample_sort_column", "sample_sort_order",
+                      "include_snapshot_link"
     """
 
     attachments_source: Union[str, None] = None
     attachments_column: Union[str, None] = None
-    data_preview_table: Union[str, None] = None
-    preview_row_limit: int = 100
-    preview_attachment_filename: str = "{table_name}_preview.csv"
-    preview_info_text: str = "Attachment contains {n} of {total} records."
+    source_table: Union[str, None] = None
+    include_csv_sample: bool = True
+    sample_row_limit: int = 100
+    sample_attachment_filename: str = "{table_name}_sample.csv"
+    sample_info_text: str = "Attachment contains {n} of {total} records."
+    sample_sort_enabled: bool = False
+    sample_sort_column: Union[str, None] = None
+    sample_sort_order: str = "asc"
+    include_snapshot_link: bool = False
 
 
 @dataclass
@@ -157,10 +164,6 @@ class AdvancedEmailOptions(ConfigurationBase):
     recipient_email_address_column: Union[str, None] = None
     subject_config: SubjectConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
     message_body_config: MessageBodyConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
-    include_custom_link: bool = False
-    custom_link_text: str = "Storage Link"
-    custom_link_url: str = ""
-    custom_link_table: Union[str, None] = None
     include_attachments: bool = True
     attachments_config: AttachmentsConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -140,10 +140,15 @@ class AttachmentsConfig(ConfigurationBase):
     attachments_source:
     "all_input_files"
     "from_table" -> "attachments_column"
+    "data_preview" -> "data_preview_table", "preview_row_limit", "preview_attachment_filename", "preview_info_text"
     """
 
     attachments_source: Union[str, None] = None
     attachments_column: Union[str, None] = None
+    data_preview_table: Union[str, None] = None
+    preview_row_limit: int = 100
+    preview_attachment_filename: str = "{table_name}_preview.csv"
+    preview_info_text: str = "Attachment contains {n} of {total} records."
 
 
 @dataclass

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -141,7 +141,7 @@ class AttachmentsConfig(ConfigurationBase):
     "all_input_files"
     "from_table" -> "attachments_column"
     "single_table" -> "source_table", "include_csv_sample", "sample_row_limit", "sample_attachment_filename",
-                      "sample_info_text", "sample_sort_enabled", "sample_sort_column", "sample_sort_order",
+                      "sample_info_text", "sort_enabled", "sort_column", "sort_order",
                       "include_snapshot_link"
     """
 
@@ -152,9 +152,9 @@ class AttachmentsConfig(ConfigurationBase):
     sample_row_limit: int = 100
     sample_attachment_filename: str = "{table_name}_sample.csv"
     sample_info_text: str = "Attachment contains {n} of {total} records."
-    sample_sort_enabled: bool = False
-    sample_sort_column: Union[str, None] = None
-    sample_sort_order: str = "asc"
+    sort_enabled: bool = False
+    sort_column: Union[str, None] = None
+    sort_order: str = "asc"
     include_snapshot_link: bool = False
 
 

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -157,6 +157,10 @@ class AdvancedEmailOptions(ConfigurationBase):
     recipient_email_address_column: Union[str, None] = None
     subject_config: SubjectConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
     message_body_config: MessageBodyConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
+    include_custom_link: bool = False
+    custom_link_text: str = "Storage Link"
+    custom_link_url: str = ""
+    custom_link_table: Union[str, None] = None
     include_attachments: bool = True
     attachments_config: AttachmentsConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
 

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,9 +1,0 @@
-import unittest
-
-
-class TestPlaceholder(unittest.TestCase):
-    def test_component_imports(self):
-        """Verify basic component imports work."""
-        from configuration import Configuration
-
-        self.assertIsNotNone(Configuration)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,444 @@
+"""
+Comprehensive test suite for configuration validation in Component.
+
+Tests cover:
+- _validate_run_configuration() method (to be implemented)
+- _resolve_data_source_table_path() method
+- load_email_data_table_path() method
+- _load_attachment_tables() method
+"""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from keboola.component.exceptions import UserException
+
+from component import Component
+from configuration import Configuration
+
+# ==================== Fixtures ====================
+
+
+@pytest.fixture
+def mock_environment():
+    """Mock environment variables."""
+    env = MagicMock()
+    env.stack_id = "connection.keboola.com"
+    env.project_id = "123"
+    env.run_id = "456"
+    return env
+
+
+@pytest.fixture
+def mock_tables_mapping():
+    """Mock tables_input_mapping with common test tables."""
+    table1 = MagicMock()
+    table1.destination = "email_basis.csv"
+    table1.source = "out.c-bucket.email_basis"
+
+    table2 = MagicMock()
+    table2.destination = "email_export.csv"
+    table2.source = "out.c-bucket.email_export_dataset"
+
+    return [table1, table2]
+
+
+@pytest.fixture
+def mock_input_tables():
+    """Mock get_input_tables_definitions() return value."""
+    table1 = MagicMock()
+    table1.name = "email_basis"
+    table1.full_path = "/data/in/tables/email_basis.csv"
+
+    table2 = MagicMock()
+    table2.name = "email_export_dataset"
+    table2.full_path = "/data/in/tables/email_export.csv"
+
+    return [table1, table2]
+
+
+@pytest.fixture
+def component(mock_environment, mock_tables_mapping, mock_input_tables):
+    """
+    Create a Component instance with mocked internals for testing.
+
+    Returns a Component with:
+    - Valid advanced configuration
+    - Mocked environment variables
+    - Mocked tables_input_mapping
+    - Mocked get_input_tables_definitions()
+    """
+    with patch("component.ComponentBase.__init__", return_value=None):
+        comp = Component()
+
+        # Set up valid default configuration
+        comp.cfg = Configuration.load_from_dict(make_advanced_config())
+
+        # Mock configuration property (read-only, needs PropertyMock)
+        mock_config = MagicMock()
+        mock_config.tables_input_mapping = mock_tables_mapping
+        mock_config.parameters = make_advanced_config()
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            comp._configuration_mock = mock_conf_prop  # Keep reference
+
+            # Mock environment variables
+            comp.environment_variables = mock_environment
+
+            # Mock get_input_tables_definitions()
+            comp.get_input_tables_definitions = MagicMock(return_value=mock_input_tables)
+
+            # Mock other required methods
+            comp._init_storage_client = MagicMock()
+            comp._count_csv_rows = MagicMock(return_value=100)
+
+            yield comp
+
+
+def make_advanced_config(**overrides) -> dict:
+    """
+    Build a valid advanced configuration dict with optional overrides.
+
+    Args:
+        **overrides: Nested dict of overrides to apply to the base config
+
+    Returns:
+        Complete configuration dict
+    """
+    config = {
+        "configuration_type": "advanced",
+        "connection_config": {
+            "use_oauth": False,
+            "creds_config": {
+                "sender_email_address": "test@example.com",
+                "server_host": "smtp.example.com",
+                "server_port": 465,
+            },
+        },
+        "advanced_options": {
+            "email_data_table_name": "email_basis.csv",
+            "recipient_email_address_column": "RECIPIENT_EMAIL",
+            "subject_config": {
+                "subject_source": "from_template_definition",
+                "subject_template_definition": "Test Subject",
+            },
+            "message_body_config": {
+                "message_body_source": "from_template_definition",
+                "use_html_template": False,
+                "plaintext_template_definition": "Test Body",
+            },
+            "include_custom_link": False,
+            "custom_link_text": "Storage Link",
+            "custom_link_url": "",
+            "custom_link_table": None,
+            "include_attachments": True,
+            "attachments_config": {
+                "attachments_source": "all_input_files",
+            },
+        },
+        "continue_on_error": True,
+        "dry_run": False,
+    }
+
+    # Apply overrides
+    _deep_update(config, overrides)
+    return config
+
+
+def _deep_update(base_dict, update_dict):
+    """Recursively update nested dictionary."""
+    for key, value in update_dict.items():
+        if isinstance(value, dict) and key in base_dict and isinstance(base_dict[key], dict):
+            _deep_update(base_dict[key], value)
+        else:
+            base_dict[key] = value
+
+
+# ==================== Tests for _validate_run_configuration() ====================
+
+
+class TestValidateRunConfiguration:
+    """Tests for the _validate_run_configuration() method."""
+
+    def test_basic_mode_skips_validation(self, component):
+        """Basic mode should skip all validation."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                configuration_type="basic",
+            )
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    # Data Preview Validation
+
+    def test_data_preview_missing_table(self, component):
+        """Data preview mode without table specified should raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "attachments_config": {
+                        "attachments_source": "data_preview",
+                        "data_preview_table": None,
+                    }
+                }
+            )
+        )
+        with pytest.raises(UserException, match="Data preview table must be specified"):
+            component._validate_run_configuration()
+
+    def test_data_preview_table_not_in_input_tables(self, component):
+        """Data preview table not found in input tables should raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "attachments_config": {
+                        "attachments_source": "data_preview",
+                        "data_preview_table": "nonexistent.csv",
+                    }
+                }
+            )
+        )
+        with pytest.raises(UserException, match="not found in input tables"):
+            component._validate_run_configuration()
+
+    def test_data_preview_valid(self, component):
+        """Valid data preview configuration should not raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "attachments_config": {
+                        "attachments_source": "data_preview",
+                        "data_preview_table": "email_export.csv",
+                    }
+                }
+            )
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    @pytest.mark.parametrize(
+        "config_override",
+        [
+            {"advanced_options": {"include_attachments": False}},
+            {"advanced_options": {"attachments_config": {"attachments_source": "from_table"}}},
+            {"advanced_options": {"attachments_config": {"attachments_source": "all_input_files"}}},
+        ],
+    )
+    def test_data_preview_not_active_skips_validation(self, component, config_override):
+        """Data preview validation skipped when not active."""
+        component.cfg = Configuration.load_from_dict(make_advanced_config(**config_override))
+        # Should not raise even without data_preview_table
+        component._validate_run_configuration()
+
+    # Custom Link Validation
+
+    def test_custom_link_disabled_skips_validation(self, component):
+        """Custom link disabled should skip validation."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(advanced_options={"include_custom_link": False})
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    def test_custom_link_table_id_placeholder_without_table(self, component):
+        """Custom link with {table_id} but no table specified should raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
+                    "custom_link_table": None,
+                }
+            )
+        )
+        with pytest.raises(UserException, match="Custom link table must be specified.*{table_id}"):
+            component._validate_run_configuration()
+
+    def test_custom_link_table_not_in_mapping(self, component):
+        """Custom link table not found in input mapping should raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
+                    "custom_link_table": "nonexistent.csv",
+                }
+            )
+        )
+        with pytest.raises(UserException, match="not found in input mapping"):
+            component._validate_run_configuration()
+
+    @pytest.mark.parametrize("missing_var", ["stack_id", "project_id", "run_id"])
+    def test_custom_link_missing_env_var(self, component, missing_var):
+        """Custom link with missing environment variable should raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://{stack}/admin/projects/{project_id}",
+                }
+            )
+        )
+        setattr(component.environment_variables, missing_var, "")
+        with pytest.raises(UserException, match=f"{missing_var.replace('_', ' ').title()}.*not available"):
+            component._validate_run_configuration()
+
+    def test_custom_link_valid_with_table_id(self, component):
+        """Valid custom link with {table_id} placeholder should not raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
+                    "custom_link_table": "email_export.csv",
+                }
+            )
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    def test_custom_link_valid_without_table_id(self, component):
+        """Valid custom link without {table_id} placeholder should not raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/overview",
+                }
+            )
+        )
+        # Should not raise (no custom_link_table needed)
+        component._validate_run_configuration()
+
+    def test_custom_link_static_url(self, component):
+        """Custom link with static URL (no placeholders) should not raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://example.com/static-page",
+                }
+            )
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    # Combined Scenarios
+
+    def test_both_features_valid(self, component):
+        """Both data preview and custom link enabled with valid config should not raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://{stack}/admin/projects/{project_id}",
+                    "attachments_config": {
+                        "attachments_source": "data_preview",
+                        "data_preview_table": "email_export.csv",
+                    },
+                }
+            )
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    def test_data_preview_valid_custom_link_invalid(self, component):
+        """Data preview valid but custom link invalid should raise."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "include_custom_link": True,
+                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
+                    "custom_link_table": "nonexistent.csv",  # Invalid
+                    "attachments_config": {
+                        "attachments_source": "data_preview",
+                        "data_preview_table": "email_export.csv",  # Valid
+                    },
+                }
+            )
+        )
+        with pytest.raises(UserException, match="not found in input mapping"):
+            component._validate_run_configuration()
+
+
+# ==================== Tests for _resolve_data_source_table_path() ====================
+
+
+class TestResolveDataSourceTablePath:
+    """Tests for the _resolve_data_source_table_path() method."""
+
+    @pytest.mark.parametrize(
+        "destination,expected_path",
+        [
+            ("email_basis.csv", "/data/in/tables/email_basis.csv"),
+            ("email_export.csv", "/data/in/tables/email_export.csv"),
+        ],
+    )
+    def test_resolve_path_success(self, component, destination, expected_path):
+        """Resolving existing table should return correct path."""
+        result = component._resolve_data_source_table_path(destination)
+        assert result == expected_path
+
+    def test_resolve_path_not_found(self, component):
+        """Resolving non-existent table should raise with available tables."""
+        with pytest.raises(UserException, match="not found in input tables"):
+            component._resolve_data_source_table_path("nonexistent.csv")
+
+    def test_resolve_path_shows_available_tables(self, component):
+        """Error message should list available tables."""
+        with pytest.raises(UserException) as exc_info:
+            component._resolve_data_source_table_path("nonexistent.csv")
+        assert "email_basis.csv" in str(exc_info.value)
+        assert "email_export.csv" in str(exc_info.value)
+
+
+# ==================== Tests for load_email_data_table_path() ====================
+
+
+class TestLoadEmailDataTablePath:
+    """Tests for the load_email_data_table_path() static method."""
+
+    @pytest.mark.parametrize(
+        "table_name,expected_path",
+        [
+            ("email_basis.csv", "/data/in/tables/email_basis.csv"),
+            ("email_export.csv", "/data/in/tables/email_export.csv"),
+        ],
+    )
+    def test_load_table_path_success(self, mock_input_tables, table_name, expected_path):
+        """Loading existing table should return correct path."""
+        result = Component.load_email_data_table_path(mock_input_tables, table_name)
+        assert result == expected_path
+
+    def test_load_table_path_not_found_returns_none(self, mock_input_tables):
+        """Loading non-existent table should return None."""
+        result = Component.load_email_data_table_path(mock_input_tables, "nonexistent.csv")
+        assert result is None
+
+
+# ==================== Tests for _load_attachment_tables() ====================
+
+
+class TestLoadAttachmentTables:
+    """Tests for the _load_attachment_tables() static method."""
+
+    def test_exclude_table_correctly(self, mock_input_tables):
+        """Excluded table should not be in result."""
+        result = Component._load_attachment_tables(mock_input_tables, "email_basis.csv")
+        assert "email_basis.csv" not in result
+        assert "email_export.csv" in result
+
+    def test_other_tables_included(self, mock_input_tables):
+        """Non-excluded tables should be included with correct paths."""
+        result = Component._load_attachment_tables(mock_input_tables, "email_basis.csv")
+        assert result["email_export.csv"] == "/data/in/tables/email_export.csv"
+
+    def test_keys_are_filenames(self, mock_input_tables):
+        """Result keys should be filenames extracted from full_path."""
+        result = Component._load_attachment_tables(mock_input_tables, "nonexistent.csv")
+        assert "email_basis.csv" in result
+        assert "email_export.csv" in result
+        # Verify the values are the full paths
+        assert result["email_basis.csv"] == "/data/in/tables/email_basis.csv"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,10 +2,11 @@
 Comprehensive test suite for configuration validation in Component.
 
 Tests cover:
-- _validate_run_configuration() method (to be implemented)
+- _validate_run_configuration() method
 - _resolve_data_source_table_path() method
 - load_email_data_table_path() method
 - _load_attachment_tables() method
+- validate_single_table_() sync action method
 """
 
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -68,32 +69,23 @@ def component(mock_environment, mock_tables_mapping, mock_input_tables):
     - Mocked tables_input_mapping
     - Mocked get_input_tables_definitions()
     """
-    with patch("component.ComponentBase.__init__", return_value=None):
-        comp = Component()
+    comp = Component.__new__(Component)
+    comp.cfg = Configuration.load_from_dict(make_advanced_config())
 
-        # Set up valid default configuration
-        comp.cfg = Configuration.load_from_dict(make_advanced_config())
+    mock_config = MagicMock()
+    mock_config.tables_input_mapping = mock_tables_mapping
+    mock_config.parameters = make_advanced_config()
 
-        # Mock configuration property (read-only, needs PropertyMock)
-        mock_config = MagicMock()
-        mock_config.tables_input_mapping = mock_tables_mapping
-        mock_config.parameters = make_advanced_config()
+    with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+        mock_conf_prop.return_value = mock_config
+        comp._configuration_mock = mock_conf_prop
 
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            comp._configuration_mock = mock_conf_prop  # Keep reference
+        comp.environment_variables = mock_environment
+        comp.get_input_tables_definitions = MagicMock(return_value=mock_input_tables)
+        comp._init_storage_client = MagicMock()
+        comp._count_csv_rows = MagicMock(return_value=100)
 
-            # Mock environment variables
-            comp.environment_variables = mock_environment
-
-            # Mock get_input_tables_definitions()
-            comp.get_input_tables_definitions = MagicMock(return_value=mock_input_tables)
-
-            # Mock other required methods
-            comp._init_storage_client = MagicMock()
-            comp._count_csv_rows = MagicMock(return_value=100)
-
-            yield comp
+        yield comp
 
 
 def make_advanced_config(**overrides) -> dict:
@@ -128,10 +120,6 @@ def make_advanced_config(**overrides) -> dict:
                 "use_html_template": False,
                 "plaintext_template_definition": "Test Body",
             },
-            "include_custom_link": False,
-            "custom_link_text": "Storage Link",
-            "custom_link_url": "",
-            "custom_link_table": None,
             "include_attachments": True,
             "attachments_config": {
                 "attachments_source": "all_input_files",
@@ -173,29 +161,29 @@ class TestValidateRunConfiguration:
 
     # Data Preview Validation
 
-    def test_data_preview_missing_table(self, component):
-        """Data preview mode without table specified should raise."""
+    def test_single_table_missing_source_table(self, component):
+        """Single table mode without source table specified should raise."""
         component.cfg = Configuration.load_from_dict(
             make_advanced_config(
                 advanced_options={
                     "attachments_config": {
-                        "attachments_source": "data_preview",
-                        "data_preview_table": None,
+                        "attachments_source": "single_table",
+                        "source_table": None,
                     }
                 }
             )
         )
-        with pytest.raises(UserException, match="Data preview table must be specified"):
+        with pytest.raises(UserException, match="Source table must be specified"):
             component._validate_run_configuration()
 
-    def test_data_preview_table_not_in_input_tables(self, component):
-        """Data preview table not found in input tables should raise."""
+    def test_single_table_source_table_not_found(self, component):
+        """Single table mode with non-existent source table should raise."""
         component.cfg = Configuration.load_from_dict(
             make_advanced_config(
                 advanced_options={
                     "attachments_config": {
-                        "attachments_source": "data_preview",
-                        "data_preview_table": "nonexistent.csv",
+                        "attachments_source": "single_table",
+                        "source_table": "nonexistent.csv",
                     }
                 }
             )
@@ -203,14 +191,67 @@ class TestValidateRunConfiguration:
         with pytest.raises(UserException, match="not found in input tables"):
             component._validate_run_configuration()
 
-    def test_data_preview_valid(self, component):
-        """Valid data preview configuration should not raise."""
+    def test_single_table_neither_toggle_enabled(self, component):
+        """Single table mode with neither CSV sample nor snapshot link enabled should raise."""
         component.cfg = Configuration.load_from_dict(
             make_advanced_config(
                 advanced_options={
                     "attachments_config": {
-                        "attachments_source": "data_preview",
-                        "data_preview_table": "email_export.csv",
+                        "attachments_source": "single_table",
+                        "source_table": "email_export.csv",
+                        "include_csv_sample": False,
+                        "include_snapshot_link": False,
+                    }
+                }
+            )
+        )
+        with pytest.raises(UserException, match="At least one option must be enabled"):
+            component._validate_run_configuration()
+
+    def test_single_table_with_csv_sample_only(self, component):
+        """Single table mode with only CSV sample enabled should pass."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "attachments_config": {
+                        "attachments_source": "single_table",
+                        "source_table": "email_export.csv",
+                        "include_csv_sample": True,
+                        "include_snapshot_link": False,
+                    }
+                }
+            )
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    def test_single_table_with_snapshot_link_only(self, component):
+        """Single table mode with only snapshot link enabled should pass."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "attachments_config": {
+                        "attachments_source": "single_table",
+                        "source_table": "email_export.csv",
+                        "include_csv_sample": False,
+                        "include_snapshot_link": True,
+                    }
+                }
+            )
+        )
+        # Should not raise
+        component._validate_run_configuration()
+
+    def test_single_table_with_both_toggles(self, component):
+        """Single table mode with both CSV sample and snapshot link enabled should pass."""
+        component.cfg = Configuration.load_from_dict(
+            make_advanced_config(
+                advanced_options={
+                    "attachments_config": {
+                        "attachments_source": "single_table",
+                        "source_table": "email_export.csv",
+                        "include_csv_sample": True,
+                        "include_snapshot_link": True,
                     }
                 }
             )
@@ -232,134 +273,21 @@ class TestValidateRunConfiguration:
         # Should not raise even without data_preview_table
         component._validate_run_configuration()
 
-    # Custom Link Validation
-
-    def test_custom_link_disabled_skips_validation(self, component):
-        """Custom link disabled should skip validation."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(advanced_options={"include_custom_link": False})
-        )
-        # Should not raise
-        component._validate_run_configuration()
-
-    def test_custom_link_table_id_placeholder_without_table(self, component):
-        """Custom link with {table_id} but no table specified should raise."""
+    def test_unknown_attachments_source(self, component):
+        """Unknown attachment source value (e.g., legacy 'data_preview') should raise clear error."""
         component.cfg = Configuration.load_from_dict(
             make_advanced_config(
                 advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
-                    "custom_link_table": None,
-                }
-            )
-        )
-        with pytest.raises(UserException, match="Custom link table must be specified.*{table_id}"):
-            component._validate_run_configuration()
-
-    def test_custom_link_table_not_in_mapping(self, component):
-        """Custom link table not found in input mapping should raise."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
-                    "custom_link_table": "nonexistent.csv",
-                }
-            )
-        )
-        with pytest.raises(UserException, match="not found in input mapping"):
-            component._validate_run_configuration()
-
-    @pytest.mark.parametrize("missing_var", ["stack_id", "project_id", "run_id"])
-    def test_custom_link_missing_env_var(self, component, missing_var):
-        """Custom link with missing environment variable should raise."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://{stack}/admin/projects/{project_id}",
-                }
-            )
-        )
-        setattr(component.environment_variables, missing_var, "")
-        with pytest.raises(UserException, match=f"{missing_var.replace('_', ' ').title()}.*not available"):
-            component._validate_run_configuration()
-
-    def test_custom_link_valid_with_table_id(self, component):
-        """Valid custom link with {table_id} placeholder should not raise."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
-                    "custom_link_table": "email_export.csv",
-                }
-            )
-        )
-        # Should not raise
-        component._validate_run_configuration()
-
-    def test_custom_link_valid_without_table_id(self, component):
-        """Valid custom link without {table_id} placeholder should not raise."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/overview",
-                }
-            )
-        )
-        # Should not raise (no custom_link_table needed)
-        component._validate_run_configuration()
-
-    def test_custom_link_static_url(self, component):
-        """Custom link with static URL (no placeholders) should not raise."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://example.com/static-page",
-                }
-            )
-        )
-        # Should not raise
-        component._validate_run_configuration()
-
-    # Combined Scenarios
-
-    def test_both_features_valid(self, component):
-        """Both data preview and custom link enabled with valid config should not raise."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://{stack}/admin/projects/{project_id}",
                     "attachments_config": {
-                        "attachments_source": "data_preview",
-                        "data_preview_table": "email_export.csv",
-                    },
+                        "attachments_source": "data_preview",  # Legacy value
+                    }
                 }
             )
         )
-        # Should not raise
-        component._validate_run_configuration()
-
-    def test_data_preview_valid_custom_link_invalid(self, component):
-        """Data preview valid but custom link invalid should raise."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "include_custom_link": True,
-                    "custom_link_url": "https://{stack}/admin/projects/{project_id}/table/{table_id}",
-                    "custom_link_table": "nonexistent.csv",  # Invalid
-                    "attachments_config": {
-                        "attachments_source": "data_preview",
-                        "data_preview_table": "email_export.csv",  # Valid
-                    },
-                }
-            )
-        )
-        with pytest.raises(UserException, match="not found in input mapping"):
+        with pytest.raises(
+            UserException,
+            match="Unknown attachment source: 'data_preview'. Valid options: 'from_table', 'single_table', 'all_input_files'",
+        ):
             component._validate_run_configuration()
 
 
@@ -442,3 +370,167 @@ class TestLoadAttachmentTables:
         assert "email_export.csv" in result
         # Verify the values are the full paths
         assert result["email_basis.csv"] == "/data/in/tables/email_basis.csv"
+
+
+# ==================== Tests for validate_single_table_() Sync Action ====================
+
+
+class TestValidateSingleTableSyncAction:
+    """Tests for the validate_single_table_() sync action helper method."""
+
+    @pytest.fixture
+    def base_config(self):
+        """Base configuration for sync action tests."""
+        return {
+            "smtp_server_config": {
+                "host": "smtp.example.com",
+                "port": 587,
+                "use_tls": True,
+                "sender_email_address": "sender@example.com",
+                "password": "#password",
+            },
+            "email_data_table_name": "email_basis.csv",
+            "subject": "Test Subject",
+            "plaintext_body": "Test body",
+            "advanced_options": {
+                "include_attachments": True,
+                "attachments_config": {
+                    "attachments_source": "single_table",
+                    "source_table": None,
+                    "include_csv_sample": False,
+                    "include_snapshot_link": False,
+                },
+            },
+        }
+
+    def test_missing_source_table(self, base_config, mock_tables_mapping):
+        """Should return error when source_table is not set."""
+        comp = Component.__new__(Component)
+        comp.cfg = Configuration.load_from_dict(base_config)
+        mock_config = MagicMock()
+        mock_config.parameters = base_config
+        mock_config.tables_input_mapping = mock_tables_mapping
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            result = comp.validate_single_table_()
+
+        assert "❌ Source table must be specified for single table mode" in result.message
+        assert result.type.name == "ERROR"
+
+    def test_source_table_not_found(self, base_config, mock_tables_mapping):
+        """Should return error when source_table doesn't exist in input tables."""
+        base_config["advanced_options"]["attachments_config"]["source_table"] = "nonexistent.csv"
+        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = True
+
+        comp = Component.__new__(Component)
+        comp.cfg = Configuration.load_from_dict(base_config)
+        mock_config = MagicMock()
+        mock_config.parameters = base_config
+        mock_config.tables_input_mapping = mock_tables_mapping
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            result = comp.validate_single_table_()
+
+        assert "❌" in result.message
+        assert "nonexistent.csv" in result.message
+        assert result.type.name == "ERROR"
+
+    def test_neither_toggle_enabled(self, base_config, mock_tables_mapping):
+        """Should return error when both include_csv_sample and include_snapshot_link are False."""
+        base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
+        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = False
+        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = False
+
+        comp = Component.__new__(Component)
+        comp.cfg = Configuration.load_from_dict(base_config)
+        mock_config = MagicMock()
+        mock_config.parameters = base_config
+        mock_config.tables_input_mapping = mock_tables_mapping
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            result = comp.validate_single_table_()
+
+        assert "❌ At least one option must be enabled" in result.message
+        assert result.type.name == "ERROR"
+
+    def test_multiple_errors_shown_together(self, base_config, mock_tables_mapping):
+        """Should show all errors at once (not fail-fast)."""
+        # Missing source_table AND neither toggle enabled
+        base_config["advanced_options"]["attachments_config"]["source_table"] = None
+        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = False
+        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = False
+
+        comp = Component.__new__(Component)
+        comp.cfg = Configuration.load_from_dict(base_config)
+        mock_config = MagicMock()
+        mock_config.parameters = base_config
+        mock_config.tables_input_mapping = mock_tables_mapping
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            result = comp.validate_single_table_()
+
+        # Both errors should be present
+        assert "❌ Source table must be specified for single table mode" in result.message
+        assert "❌ At least one option must be enabled" in result.message
+        assert result.type.name == "ERROR"
+
+    def test_csv_sample_only_valid(self, base_config, mock_tables_mapping):
+        """Should succeed when only include_csv_sample is enabled."""
+        base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
+        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = True
+        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = False
+
+        comp = Component.__new__(Component)
+        comp.cfg = Configuration.load_from_dict(base_config)
+        mock_config = MagicMock()
+        mock_config.parameters = base_config
+        mock_config.tables_input_mapping = mock_tables_mapping
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            result = comp.validate_single_table_()
+
+        assert "✅" in result.message
+        assert result.type.name == "SUCCESS"
+
+    def test_snapshot_link_only_valid(self, base_config, mock_tables_mapping):
+        """Should succeed when only include_snapshot_link is enabled."""
+        base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
+        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = False
+        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = True
+
+        comp = Component.__new__(Component)
+        comp.cfg = Configuration.load_from_dict(base_config)
+        mock_config = MagicMock()
+        mock_config.parameters = base_config
+        mock_config.tables_input_mapping = mock_tables_mapping
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            result = comp.validate_single_table_()
+
+        assert "✅" in result.message
+        assert result.type.name == "SUCCESS"
+
+    def test_both_toggles_enabled_valid(self, base_config, mock_tables_mapping):
+        """Should succeed when both toggles are enabled."""
+        base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
+        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = True
+        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = True
+
+        comp = Component.__new__(Component)
+        comp.cfg = Configuration.load_from_dict(base_config)
+        mock_config = MagicMock()
+        mock_config.parameters = base_config
+        mock_config.tables_input_mapping = mock_tables_mapping
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            result = comp.validate_single_table_()
+
+        assert "✅" in result.message
+        assert result.type.name == "SUCCESS"

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "component-email-smtp-sender"
 source = { virtual = "." }
 dependencies = [
@@ -153,6 +162,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -169,7 +179,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.0" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.15.0" },
+]
 
 [[package]]
 name = "cryptography"
@@ -354,6 +367,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -478,6 +500,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "proto-plus"
 version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -544,6 +584,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyhocon"
 version = "0.3.61"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +633,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add data preview attachment mode: attach first N rows of a selected table as CSV
- Add custom link feature: append a configurable URL with placeholders to email body
- Fix table lookup to match on filename from full_path instead of table name
- Centralize runtime validation into _validate_run_configuration() method
- Add pytest test suite with 28 tests covering validation, table resolution, and attachments
- Update configRow schema with new UI fields, tooltips, and async table selectors