### PR TITLE
fix: table path lookup, Path.rename crash & legacy attachment config regression

### DIFF
--- a/.claude/component-factory-setup.sh
+++ b/.claude/component-factory-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Skip if project doesn't use pre-commit
+if ! test -f pyproject.toml || ! test -f .pre-commit-config.yaml; then
+    echo '{"systemMessage": "⚠️ Pre-commit hooks: project does not use pre-commit, skipping setup"}'
+    exit 0
+fi
+
+# Check if already installed
+if test -f .git/hooks/pre-commit; then
+    echo '{"systemMessage": "✅ Pre-commit hooks already installed"}'
+    exit 0
+fi
+
+# Install
+if uv sync && uv run pre-commit install; then
+    echo '{"systemMessage": "✅ Pre-commit hooks installed successfully"}'
+else
+    echo '{"systemMessage": "❌ Pre-commit hooks failed to install"}'
+    exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/component-factory-setup.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -133,6 +133,7 @@ jobs:
           docker load --input /tmp/${{ env.KBC_DEVELOPERPORTAL_APP }}.tar
           docker image ls -a
           docker run ${{ env.KBC_DEVELOPERPORTAL_APP }}:latest ruff check .
+          docker run ${{ env.KBC_DEVELOPERPORTAL_APP }}:latest ruff format --check .
           echo "Running unit-tests..."
           docker run ${{ env.KBC_DEVELOPERPORTAL_APP }}:latest pytest
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,8 +63,13 @@ jobs:
       - name: Set image tag
         id: tag
         run: |
-          TAG="${GITHUB_REF##*/}"
-          IS_SEMANTIC_TAG=$(echo "$TAG" | grep -q '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
+          REF="${GITHUB_REF##*/}"
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            TAG="$REF"
+          else
+            TAG="$REF-${{ github.run_number }}"
+          fi
+          IS_SEMANTIC_TAG=$(echo "$REF" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
           echo "is_semantic_tag=$IS_SEMANTIC_TAG" | tee -a $GITHUB_OUTPUT
           echo "app_image_tag=$TAG" | tee -a $GITHUB_OUTPUT
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-format-check
+        name: ruff format check
+        entry: uv run ruff format --check
+        language: system
+        types: [python]
+        pass_filenames: false
+
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check
+        language: system
+        types: [python]
+        pass_filenames: false
+
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+
+      - id: ty-check
+        name: ty type check (warnings only)
+        entry: bash -c 'output=$(uv run ty check -q 2>&1); if echo "$output" | grep -q "Found 0 diagnostics"; then echo "✅ $output"; else echo "❌ $output"; fi; true'
+        language: system
+        types: [python]
+        pass_filenames: false
+        verbose: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+## IMPORTANT: Run before ANY work
+
+```bash
+.claude/component-factory-setup.sh
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,18 @@ dependencies = [
 dev = [
     "pytest>=9.0.2",
     "ruff>=0.15.0",
+    "pre-commit>=4.0.0",
+    "ty>=0.0.20",
 ]
 
 [tool.ruff]
 line-length = 120
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = [
+    "I",        # isort: import sorting
+    "PLR6301",  # pylint: method could be static
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/component.py
+++ b/src/component.py
@@ -76,11 +76,18 @@ class Component(ComponentBase):
         self.html_template_path = None
 
     def run(self):
+        try:
+            self._run()
+        except Exception:
+            logging.exception("Unhandled exception in run()")
+            raise
+
+    def _run(self):
         self._validate_run_configuration()
         self.init_client()
 
         if self.cfg.configuration_type == "advanced":
-            validation_results = self.validate_config()
+            validation_results = self._validate_config()
             if validation_results.type == MessageType.DANGER:
                 raise UserException(validation_results.message)
 
@@ -739,9 +746,10 @@ class Component(ComponentBase):
         return template_text
 
     def _init_storage_client(self) -> StorageClient:
-        storage_token = self.environment_variables.token
-        storage_client = StorageClient(self.environment_variables.url, storage_token)
-        return storage_client
+        if not self.environment_variables.token or not self.environment_variables.url:
+            logging.warning("Storage API not available (missing token or URL), skipping storage client init.")
+            return None
+        return StorageClient(self.environment_variables.url, self.environment_variables.token)
 
     def _return_table_path(self, table_name: str) -> str:
         table_path = None
@@ -807,11 +815,9 @@ class Component(ComponentBase):
             # Load columns only if we have placeholders to validate
             columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
 
-            # If loading failed, we can't validate - return error (strict)
+            # If loading failed (e.g. Storage API unavailable), pass through as-is
             if isinstance(columns, ValidationResult):
-                return ValidationResult(
-                    "❌ Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
-                )
+                return columns
 
             # Validate placeholders against columns
             try:
@@ -857,7 +863,7 @@ class Component(ComponentBase):
             reader = csv.DictReader(StringIO(preview))
             return reader.fieldnames
         except Exception:
-            return ValidationResult("Couldn't fetch columns", MessageType.DANGER)
+            return ValidationResult("⚠️ Column validation skipped: Storage API not accessible.", MessageType.WARNING)
 
     @sync_action("load_input_table_columns")
     def load_input_table_columns(self) -> list[SelectElement]:
@@ -899,11 +905,9 @@ class Component(ComponentBase):
             # Load columns only if we have placeholders to validate
             columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
 
-            # If loading failed, we can't validate - return error (strict)
+            # If loading failed (e.g. Storage API unavailable), pass through as-is
             if isinstance(columns, ValidationResult):
-                return ValidationResult(
-                    "❌ Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
-                )
+                return columns
 
             # Validate placeholders against columns
             try:
@@ -999,6 +1003,9 @@ class Component(ComponentBase):
 
     @sync_action("validate_config")
     def validate_config(self) -> ValidationResult:
+        return self._validate_config()
+
+    def _validate_config(self) -> ValidationResult:
         # TODO: once sys.stdout is None handling is released, remove helper methods and use other sync actions directly
         validation_methods = [
             self.test_smtp_server_connection_,

--- a/src/component.py
+++ b/src/component.py
@@ -49,8 +49,14 @@ RESULT_TABLE_COLUMNS = (
 
 VALID_CONNECTION_CONFIG_MESSAGE = "✅ Connection configuration is valid"
 VALID_SUBJECT_MESSAGE = "✅ All subject placeholders are present in the input table"
+VALID_SUBJECT_COLUMN_MESSAGE = "✅ Subject column exists in the input table"
+VALID_SUBJECT_NO_PLACEHOLDERS_MESSAGE = "✅ Subject has no placeholders to validate"
 VALID_PLAINTEXT_TEMPLATE_MESSAGE = "✅ All plaintext template placeholders are present in the input table"
+VALID_PLAINTEXT_TEMPLATE_COLUMN_MESSAGE = "✅ Plaintext template column exists in the input table"
+VALID_PLAINTEXT_TEMPLATE_NO_PLACEHOLDERS_MESSAGE = "✅ Plaintext template has no placeholders to validate"
 VALID_HTML_TEMPLATE_MESSAGE = "✅ All HTML template placeholders are present in the input table"
+VALID_HTML_TEMPLATE_COLUMN_MESSAGE = "✅ HTML template column exists in the input table"
+VALID_HTML_TEMPLATE_NO_PLACEHOLDERS_MESSAGE = "✅ HTML template has no placeholders to validate"
 VALID_ATTACHMENTS_MESSAGE = "✅ All attachments are present"
 
 general_error_row = {
@@ -581,6 +587,8 @@ class Component(ComponentBase):
 
     @staticmethod
     def _parse_template_placeholders(template_text: str) -> Set[str]:
+        if not template_text:
+            return set()
         placeholders = re.findall(r"\{\{.*?\}\}", template_text)
         placeholders = set([placeholder.strip("{}") for placeholder in placeholders])
         return placeholders
@@ -594,16 +602,16 @@ class Component(ComponentBase):
 
     def _get_attachments_filenames_from_table(self, in_table_path: str) -> Set[str]:
         attachments_filenames = set()
+        attachments_column = self.cfg.advanced_options.attachments_config.attachments_column
         try:
             with open(in_table_path) as in_table:
                 reader = csv.DictReader(in_table)
-                attachments_column = self.cfg.advanced_options.attachments_config.attachments_column
                 for row in reader:
                     for attachment_filename in json.loads(row[attachments_column]):
                         attachments_filenames.add(attachment_filename)
         except Exception as e:
             raise UserException(
-                f"Couldn't read attachments from table {in_table_path} column {attachments_column}: {str(e)}"
+                f"❌ Column '{attachments_column}' does not contain valid JSON attachment data: {str(e)}"
             )
         return attachments_filenames
 
@@ -705,15 +713,18 @@ class Component(ComponentBase):
         return missing_columns
 
     def _validate_templates_from_table(self, reader: csv.DictReader, plaintext: bool) -> ValidationResult:
-        message = VALID_PLAINTEXT_TEMPLATE_MESSAGE if plaintext else VALID_HTML_TEMPLATE_MESSAGE
+        valid_column_message = (
+            VALID_PLAINTEXT_TEMPLATE_COLUMN_MESSAGE if plaintext else VALID_HTML_TEMPLATE_COLUMN_MESSAGE
+        )
         key_template_column = KEY_PLAINTEXT_TEMPLATE_COLUMN if plaintext else KEY_HTML_TEMPLATE_COLUMN
-        message_type = MessageType.SUCCESS
         template_column = self.cfg.advanced_options.message_body_config[key_template_column]
+        if not template_column:
+            label = "Plaintext template" if plaintext else "HTML template"
+            return ValidationResult(f"❌ {label} column is not specified", MessageType.DANGER)
         missing_columns = self._get_missing_columns_from_table(reader, template_column)
         if missing_columns:
-            message = "❌ Missing columns: " + ", ".join(missing_columns)
-            message_type = MessageType.DANGER
-        return ValidationResult(message, message_type)
+            return ValidationResult("❌ Missing columns: " + ", ".join(missing_columns), MessageType.DANGER)
+        return ValidationResult(valid_column_message, MessageType.SUCCESS)
 
     def _read_template_text(self, plaintext: bool = True) -> str:
         """Reads in template either from file, or from config"""
@@ -788,6 +799,11 @@ class Component(ComponentBase):
 
     def _validate_template(self, plaintext: bool = True) -> ValidationResult:
         valid_message = VALID_PLAINTEXT_TEMPLATE_MESSAGE if plaintext else VALID_HTML_TEMPLATE_MESSAGE
+        no_placeholders_message = (
+            VALID_PLAINTEXT_TEMPLATE_NO_PLACEHOLDERS_MESSAGE
+            if plaintext
+            else VALID_HTML_TEMPLATE_NO_PLACEHOLDERS_MESSAGE
+        )
         if self.cfg.advanced_options.message_body_config.message_body_source == "from_table":
             table_name = self.cfg.advanced_options.email_data_table_name
             in_table_path = self._return_table_path(table_name)
@@ -802,7 +818,7 @@ class Component(ComponentBase):
 
             # If no placeholders, validation passes immediately
             if not template_placeholders:
-                return ValidationResult(valid_message, MessageType.SUCCESS)
+                return ValidationResult(no_placeholders_message, MessageType.SUCCESS)
 
             # Load columns only if we have placeholders to validate
             columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
@@ -877,6 +893,8 @@ class Component(ComponentBase):
         subject_config = self.cfg.advanced_options.subject_config
         if subject_config.subject_source == "from_table":
             subject_column = subject_config.subject_column
+            if not subject_column:
+                return ValidationResult("❌ Subject column is not specified", MessageType.DANGER)
             table_name = self.cfg.advanced_options.email_data_table_name
             in_table_path = self._return_table_path(table_name)
             with open(in_table_path) as in_table:
@@ -885,7 +903,7 @@ class Component(ComponentBase):
                 if missing_columns:
                     message = "❌ Missing columns: " + ", ".join(missing_columns)
                     return ValidationResult(message, MessageType.DANGER)
-                return ValidationResult(VALID_SUBJECT_MESSAGE, MessageType.SUCCESS)
+                return ValidationResult(VALID_SUBJECT_COLUMN_MESSAGE, MessageType.SUCCESS)
         else:
             subject_template_text = subject_config.subject_template_definition
 
@@ -894,7 +912,7 @@ class Component(ComponentBase):
 
             # If no placeholders, validation passes immediately
             if not template_placeholders:
-                return ValidationResult(VALID_SUBJECT_MESSAGE, MessageType.SUCCESS)
+                return ValidationResult(VALID_SUBJECT_NO_PLACEHOLDERS_MESSAGE, MessageType.SUCCESS)
 
             # Load columns only if we have placeholders to validate
             columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
@@ -934,6 +952,9 @@ class Component(ComponentBase):
         message = VALID_ATTACHMENTS_MESSAGE
         try:
             if self.cfg.advanced_options.attachments_config.attachments_source == "from_table":
+                attachments_column = self.cfg.advanced_options.attachments_config.attachments_column
+                if not attachments_column:
+                    return ValidationResult("❌ Attachments column is not specified", MessageType.DANGER)
                 table_name = self.cfg.advanced_options.email_data_table_name
                 in_table_path = self._return_table_path(table_name)
                 expected_input_filenames = self._get_attachments_filenames_from_table(in_table_path)

--- a/src/component.py
+++ b/src/component.py
@@ -76,18 +76,11 @@ class Component(ComponentBase):
         self.html_template_path = None
 
     def run(self):
-        try:
-            self._run()
-        except Exception:
-            logging.exception("Unhandled exception in run()")
-            raise
-
-    def _run(self):
         self._validate_run_configuration()
         self.init_client()
 
         if self.cfg.configuration_type == "advanced":
-            validation_results = self._validate_config()
+            validation_results = self.validate_config()
             if validation_results.type == MessageType.DANGER:
                 raise UserException(validation_results.message)
 
@@ -746,10 +739,9 @@ class Component(ComponentBase):
         return template_text
 
     def _init_storage_client(self) -> StorageClient:
-        if not self.environment_variables.token or not self.environment_variables.url:
-            logging.warning("Storage API not available (missing token or URL), skipping storage client init.")
-            return None
-        return StorageClient(self.environment_variables.url, self.environment_variables.token)
+        storage_token = self.environment_variables.token
+        storage_client = StorageClient(self.environment_variables.url, storage_token)
+        return storage_client
 
     def _return_table_path(self, table_name: str) -> str:
         table_path = None
@@ -815,9 +807,11 @@ class Component(ComponentBase):
             # Load columns only if we have placeholders to validate
             columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
 
-            # If loading failed (e.g. Storage API unavailable), pass through as-is
+            # If loading failed, we can't validate - return error (strict)
             if isinstance(columns, ValidationResult):
-                return columns
+                return ValidationResult(
+                    "❌ Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
+                )
 
             # Validate placeholders against columns
             try:
@@ -863,7 +857,7 @@ class Component(ComponentBase):
             reader = csv.DictReader(StringIO(preview))
             return reader.fieldnames
         except Exception:
-            return ValidationResult("⚠️ Column validation skipped: Storage API not accessible.", MessageType.WARNING)
+            return ValidationResult("Couldn't fetch columns", MessageType.DANGER)
 
     @sync_action("load_input_table_columns")
     def load_input_table_columns(self) -> list[SelectElement]:
@@ -905,9 +899,11 @@ class Component(ComponentBase):
             # Load columns only if we have placeholders to validate
             columns = self._load_table_columns(self.cfg.advanced_options.email_data_table_name, "Email Data Table Name")
 
-            # If loading failed (e.g. Storage API unavailable), pass through as-is
+            # If loading failed, we can't validate - return error (strict)
             if isinstance(columns, ValidationResult):
-                return columns
+                return ValidationResult(
+                    "❌ Cannot validate placeholders: email data table is not accessible", MessageType.DANGER
+                )
 
             # Validate placeholders against columns
             try:
@@ -1003,9 +999,6 @@ class Component(ComponentBase):
 
     @sync_action("validate_config")
     def validate_config(self) -> ValidationResult:
-        return self._validate_config()
-
-    def _validate_config(self) -> ValidationResult:
         # TODO: once sys.stdout is None handling is released, remove helper methods and use other sync actions directly
         validation_methods = [
             self.test_smtp_server_connection_,

--- a/src/component.py
+++ b/src/component.py
@@ -734,6 +734,9 @@ class Component(ComponentBase):
         if message_body_source == "from_template_file":
             key_template_filename = KEY_PLAINTEXT_TEMPLATE_FILENAME if plaintext else KEY_HTML_TEMPLATE_FILENAME
             template_filename = message_body_config[key_template_filename]
+            label = "Plaintext template" if plaintext else "HTML template"
+            if not template_filename:
+                raise UserException(f"❌ {label} filename is not specified")
             files = self._list_files_in_sync_actions()
             if not files:
                 raise UserException(
@@ -806,12 +809,17 @@ class Component(ComponentBase):
         )
         if self.cfg.advanced_options.message_body_config.message_body_source == "from_table":
             table_name = self.cfg.advanced_options.email_data_table_name
+            if not table_name:
+                return ValidationResult("❌ Email data table is not specified", MessageType.DANGER)
             in_table_path = self._return_table_path(table_name)
             with open(in_table_path) as in_table:
                 reader = csv.DictReader(in_table)
                 return self._validate_templates_from_table(reader, plaintext)
         else:
-            template_text = self._read_template_text(plaintext)
+            try:
+                template_text = self._read_template_text(plaintext)
+            except UserException as e:
+                return ValidationResult(str(e), MessageType.DANGER)
 
             # Parse placeholders first
             template_placeholders = self._parse_template_placeholders(template_text)
@@ -896,6 +904,8 @@ class Component(ComponentBase):
             if not subject_column:
                 return ValidationResult("❌ Subject column is not specified", MessageType.DANGER)
             table_name = self.cfg.advanced_options.email_data_table_name
+            if not table_name:
+                return ValidationResult("❌ Email data table is not specified", MessageType.DANGER)
             in_table_path = self._return_table_path(table_name)
             with open(in_table_path) as in_table:
                 reader = csv.DictReader(in_table)
@@ -956,6 +966,8 @@ class Component(ComponentBase):
                 if not attachments_column:
                     return ValidationResult("❌ Attachments column is not specified", MessageType.DANGER)
                 table_name = self.cfg.advanced_options.email_data_table_name
+                if not table_name:
+                    return ValidationResult("❌ Email data table is not specified", MessageType.DANGER)
                 in_table_path = self._return_table_path(table_name)
                 expected_input_filenames = self._get_attachments_filenames_from_table(in_table_path)
                 input_filenames = set([file["name"] for file in self._list_files_in_sync_actions()])
@@ -1020,6 +1032,10 @@ class Component(ComponentBase):
 
     @sync_action("validate_config")
     def validate_config(self) -> ValidationResult:
+        recipient_column = self.cfg.advanced_options.recipient_email_address_column
+        if not recipient_column:
+            return ValidationResult("❌ Recipient email address column is not specified", MessageType.DANGER)
+
         # TODO: once sys.stdout is None handling is released, remove helper methods and use other sync actions directly
         validation_methods = [
             self.test_smtp_server_connection_,

--- a/src/component.py
+++ b/src/component.py
@@ -36,6 +36,8 @@ KEY_DISABLE_ATTACHMENTS = "disable_attachments"
 
 SLEEP_INTERVAL = 0.1
 
+VALID_ATTACHMENT_SOURCES = ("all_input_files", "from_table", "single_table")
+
 RESULT_TABLE_COLUMNS = (
     "status",
     "recipient_email_address",
@@ -215,13 +217,14 @@ class Component(ComponentBase):
         if self.cfg.configuration_type == "basic":
             return
 
-        # Validate attachment source is a recognized value (early check)
+        # Validate attachment source is a recognized value (early check).
+        # Falsy value (None, empty string) means the user never configured attachments — silently skip.
         if self.cfg.advanced_options.include_attachments:
             attachments_source = self.cfg.advanced_options.attachments_config.attachments_source
-            if attachments_source not in ("from_table", "single_table", "all_input_files"):
+            if attachments_source and attachments_source not in VALID_ATTACHMENT_SOURCES:
                 raise UserException(
                     f"Unknown attachment source: '{attachments_source}'. "
-                    f"Valid options: 'from_table', 'single_table', 'all_input_files'"
+                    f"Valid options: {', '.join(repr(s) for s in VALID_ATTACHMENT_SOURCES)}"
                 )
 
         # Validate single table mode configuration
@@ -1049,15 +1052,17 @@ class Component(ComponentBase):
         if self.cfg.advanced_options.include_attachments and not disable_attachments:
             attachments_source = self.cfg.advanced_options.attachments_config.attachments_source
 
-            # Early return for unrecognized attachment source values (e.g., legacy configs)
-            if attachments_source not in ("from_table", "single_table", "all_input_files"):
+            if not attachments_source:
+                # Falsy value (None, empty string) means never configured — silently skip
+                pass
+            elif attachments_source not in VALID_ATTACHMENT_SOURCES:
+                # Unrecognized value (e.g., typo or future enum value) — surface as error
                 return ValidationResult(
                     f"❌ Unknown attachment source: '{attachments_source}'. "
-                    f"Valid options: 'from_table', 'single_table', 'all_input_files'",
+                    f"Valid options: {', '.join(repr(s) for s in VALID_ATTACHMENT_SOURCES)}",
                     MessageType.DANGER,
                 )
-
-            if attachments_source == "single_table":
+            elif attachments_source == "single_table":
                 validation_methods.append(self.validate_single_table_)
             elif attachments_source == "from_table":
                 validation_methods.append(self.validate_attachments_)

--- a/src/component.py
+++ b/src/component.py
@@ -340,12 +340,11 @@ class Component(ComponentBase):
         attachment_files = {}
         for name, files in in_files_by_name.items():
             file = files[0]
-            original_path = file.full_path
-            if original_path not in [self.plaintext_template_path, self.html_template_path]:
-                directory = os.path.split(original_path)[0]
-                new_path = os.path.join(directory, file.name)
-                Path.rename(original_path, new_path)
-                attachment_files[file.name] = new_path
+            original = Path(file.full_path)
+            if str(original) not in [self.plaintext_template_path, self.html_template_path]:
+                new = original.parent / file.name
+                original.rename(new)
+                attachment_files[file.name] = str(new)
         return attachment_files
 
     def load_attachment_paths_by_filename(self, in_tables, email_data_table_name, in_files_by_name):

--- a/src/component.py
+++ b/src/component.py
@@ -748,7 +748,7 @@ class Component(ComponentBase):
         if self.configuration.action == "run":
             all_tables = self.get_input_tables_definitions()
             for table in all_tables:
-                if table_name == table.name:
+                if table_name == Path(table.full_path).name:
                     table_path = table.full_path
                     break
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -362,9 +362,38 @@ class TestValidateRunConfiguration:
         )
         with pytest.raises(
             UserException,
-            match="Unknown attachment source: 'data_preview'. Valid options: 'from_table', 'single_table', 'all_input_files'",
+            match="Unknown attachment source: 'data_preview'. Valid options: 'all_input_files', 'from_table', 'single_table'",
         ):
             component._validate_run_configuration()
+
+    @pytest.mark.parametrize(
+        "advanced_options",
+        [
+            # attachments_source missing, include_attachments defaulting to True (498 legacy rows in production)
+            pytest.param({}, id="both_missing_all_defaults"),
+            # attachments_source explicitly None
+            pytest.param({"attachments_config": {"attachments_source": None}}, id="attachments_source_none"),
+            # attachments_source empty string (defensive — falsy non-None)
+            pytest.param({"attachments_config": {"attachments_source": ""}}, id="attachments_source_empty_string"),
+            # include_attachments explicitly True, attachments_source missing (the regression case)
+            pytest.param({"include_attachments": True}, id="include_attachments_true_source_missing"),
+            # include_attachments explicitly True, attachments_source explicitly None
+            pytest.param(
+                {"include_attachments": True, "attachments_config": {"attachments_source": None}},
+                id="include_attachments_true_source_none",
+            ),
+        ],
+    )
+    def test_falsy_attachments_source_does_not_raise(self, component, advanced_options):
+        """Falsy attachments_source (None, empty string, missing) must be silently ignored.
+
+        498 production rows have include_attachments missing (defaults True) but a valid attachments_source set,
+        so the True default is intentional for backwards compatibility. However, 58 rows have BOTH missing —
+        those must not crash. Our regression: deploying strict 'Unknown attachment source: None' validation
+        broke customer projects that had been running successfully without attachments configured.
+        """
+        component.cfg = Configuration.load_from_dict(make_advanced_config(advanced_options=advanced_options))
+        component._validate_run_configuration()  # must not raise
 
 
 # ==================== Tests for _resolve_data_source_table_path() ====================
@@ -1363,6 +1392,33 @@ class TestValidateConfig:
 
         assert result.type.name == "ERROR"
         assert "❌ Unknown attachment source: 'data_preview'" in result.message
+        comp.validate_attachments_.assert_not_called()
+        comp.validate_single_table_.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "advanced_options",
+        [
+            pytest.param({}, id="both_missing_all_defaults"),
+            pytest.param({"attachments_config": {"attachments_source": None}}, id="attachments_source_none"),
+            pytest.param({"attachments_config": {"attachments_source": ""}}, id="attachments_source_empty_string"),
+            pytest.param({"include_attachments": True}, id="include_attachments_true_source_missing"),
+            pytest.param(
+                {"include_attachments": True, "attachments_config": {"attachments_source": None}},
+                id="include_attachments_true_source_none",
+            ),
+        ],
+    )
+    def test_falsy_attachments_source_skips_attachment_validators(self, advanced_options):
+        """Falsy attachments_source → attachment validators not called, validate_config succeeds.
+
+        Mirrors test_falsy_attachments_source_does_not_raise but for the dry-run/sync-action path.
+        Customer projects running advanced mode without attachments configured all hit this code path.
+        """
+        config = make_advanced_config(advanced_options=advanced_options)
+        with make_component_for_validate_config(config) as comp:
+            result = comp.validate_config()
+
+        assert result.type.name == "SUCCESS"
         comp.validate_attachments_.assert_not_called()
         comp.validate_single_table_.assert_not_called()
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -447,6 +447,111 @@ class TestLoadAttachmentTables:
         assert result["email_basis.csv"] == "/data/in/tables/email_basis.csv"
 
 
+# ==================== Tests for _load_attachment_files() ====================
+
+
+class TestLoadAttachmentFiles:
+    """Tests for the _load_attachment_files() method.
+
+    The method renames each input file from its hashed storage path
+    (e.g. /data/in/files/12345_invoice.pdf) to its human-readable name
+    (e.g. /data/in/files/invoice.pdf) and returns a {filename: new_path} dict.
+
+    BUG REPRODUCED (Keboola error: "Error loading attachments: 'str' object has no
+    attribute 'with_segments'"):
+    The original code called Path.rename(original_path, new_path) where both
+    arguments are plain strings. In Python 3.12+, Path.rename() called as a
+    class method requires a Path as its first argument (self), not a str.
+    Fix: Path(original_path).rename(new_path) — instantiate first, then rename.
+    """
+
+    def _make_component(self, plaintext_template_path=None, html_template_path=None):
+        """Build a minimal Component with template path attributes set."""
+        comp = Component.__new__(Component)
+        comp.plaintext_template_path = plaintext_template_path
+        comp.html_template_path = html_template_path
+        return comp
+
+    def _make_file_mock(self, full_path: str, name: str):
+        """Build a file definition mock matching keboola.component's FileDefinition API."""
+        f = MagicMock()
+        f.full_path = full_path
+        f.name = name
+        return f
+
+    def test_renames_files_and_returns_dict(self, tmp_path):
+        """
+        REGRESSION: reproduces "Error loading attachments: 'str' object has no
+        attribute 'with_segments'" from Keboola.
+
+        Path.rename(str, str) fails in Python 3.12+ because the class-method form
+        requires a Path instance as self, not a plain string. The fix is
+        Path(original_path).rename(new_path).
+        """
+        # Create a real file with a hashed storage name (as Keboola downloads it)
+        hashed = tmp_path / "12345_invoice_2024_q4.pdf"
+        hashed.write_bytes(b"%PDF placeholder")
+
+        expected_new_path = str(tmp_path / "invoice_2024_q4.pdf")
+
+        file_mock = self._make_file_mock(str(hashed), "invoice_2024_q4.pdf")
+        comp = self._make_component()
+
+        result = comp._load_attachment_files({"invoice_2024_q4.pdf": [file_mock]})
+
+        assert result == {"invoice_2024_q4.pdf": expected_new_path}
+        assert not hashed.exists(), "original hashed file should be gone after rename"
+        assert (tmp_path / "invoice_2024_q4.pdf").exists(), "renamed file should exist"
+
+    def test_multiple_files_all_renamed(self, tmp_path):
+        """All input files (except templates) are renamed and returned."""
+        files_data = [
+            ("11111_invoice_2024_q4.pdf", "invoice_2024_q4.pdf"),
+            ("22222_service_agreement.pdf", "service_agreement.pdf"),
+            ("33333_quarterly_report.xlsx", "quarterly_report.xlsx"),
+        ]
+        in_files_by_name = {}
+        for hashed_name, clean_name in files_data:
+            path = tmp_path / hashed_name
+            path.write_bytes(b"content")
+            in_files_by_name[clean_name] = [self._make_file_mock(str(path), clean_name)]
+
+        comp = self._make_component()
+        result = comp._load_attachment_files(in_files_by_name)
+
+        assert set(result.keys()) == {"invoice_2024_q4.pdf", "service_agreement.pdf", "quarterly_report.xlsx"}
+        for clean_name in result:
+            assert (tmp_path / clean_name).exists()
+
+    def test_template_files_excluded(self, tmp_path):
+        """Files matching plaintext_template_path or html_template_path are skipped."""
+        plaintext_hashed = tmp_path / "99999_template.txt"
+        plaintext_hashed.write_text("Dear {{name}}")
+        attachment_hashed = tmp_path / "44444_invoice.pdf"
+        attachment_hashed.write_bytes(b"data")
+
+        plaintext_mock = self._make_file_mock(str(plaintext_hashed), "template.txt")
+        attachment_mock = self._make_file_mock(str(attachment_hashed), "invoice.pdf")
+
+        comp = self._make_component(plaintext_template_path=str(plaintext_hashed))
+
+        result = comp._load_attachment_files(
+            {
+                "template.txt": [plaintext_mock],
+                "invoice.pdf": [attachment_mock],
+            }
+        )
+
+        assert "template.txt" not in result, "template file must be excluded"
+        assert "invoice.pdf" in result
+
+    def test_empty_input_returns_empty_dict(self):
+        """No input files → empty result, no error."""
+        comp = self._make_component()
+        result = comp._load_attachment_files({})
+        assert result == {}
+
+
 # ==================== Tests for _return_table_path() ====================
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,9 +6,19 @@ Tests cover:
 - _resolve_data_source_table_path() method
 - load_email_data_table_path() method
 - _load_attachment_tables() method
+- _return_table_path() method
 - validate_single_table_() sync action method
+- validate_subject_() sync action helper
+- validate_plaintext_template_() / validate_html_template_() sync action helpers
+- validate_attachments_() sync action helper
+- validate_config() sync action method
+- _parse_template_placeholders() static method
 """
 
+import shutil
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -17,7 +27,7 @@ from keboola.component.exceptions import UserException
 from component import Component
 from configuration import Configuration
 
-# ==================== Fixtures ====================
+# ==================== Fixtures & shared helpers ====================
 
 
 @pytest.fixture
@@ -69,6 +79,10 @@ def component(mock_environment, mock_tables_mapping, mock_input_tables):
     - Mocked tables_input_mapping
     - Mocked get_input_tables_definitions()
     """
+    # ComponentBase.__init__ requires a real KBC_DATADIR on disk with config.json,
+    # Storage API credentials, and other runtime infrastructure that doesn't exist
+    # in unit tests. __new__ skips __init__ entirely so we can patch in only the
+    # minimal attributes each test actually needs.
     comp = Component.__new__(Component)
     comp.cfg = Configuration.load_from_dict(make_advanced_config())
 
@@ -129,7 +143,6 @@ def make_advanced_config(**overrides) -> dict:
         "dry_run": False,
     }
 
-    # Apply overrides
     _deep_update(config, overrides)
     return config
 
@@ -143,6 +156,115 @@ def _deep_update(base_dict, update_dict):
             base_dict[key] = value
 
 
+@contextmanager
+def make_component_for_sync(config: dict, table_csv: str = None):
+    """
+    Build a Component with mocked internals for sync action validation tests.
+
+    Optionally writes `table_csv` content to a temp file and mocks
+    `_return_table_path` to return its path.
+    """
+    tmpdir_holder = []
+
+    comp = Component.__new__(Component)
+    comp.cfg = Configuration.load_from_dict(config)
+
+    mock_env = MagicMock()
+    mock_env.stack_id = "connection.keboola.com"
+    mock_env.token = None
+    comp.environment_variables = mock_env
+
+    table1 = MagicMock()
+    table1.destination = "email_basis.csv"
+    table1.source = "out.c-bucket.email_basis"
+
+    mock_conf = MagicMock()
+    mock_conf.tables_input_mapping = [table1]
+    mock_conf.action = "validate_config"
+
+    with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+        mock_conf_prop.return_value = mock_conf
+
+        if table_csv is not None:
+            tmpdir = tempfile.mkdtemp()
+            tmpdir_holder.append(tmpdir)
+            csv_path = Path(tmpdir) / "email_basis.csv"
+            csv_path.write_text(table_csv)
+            comp._return_table_path = MagicMock(return_value=str(csv_path))
+        else:
+            comp._return_table_path = MagicMock(return_value=None)
+
+        yield comp
+
+    if tmpdir_holder:
+        shutil.rmtree(tmpdir_holder[0], ignore_errors=True)
+
+
+def _mock_template_file(comp, content: str) -> None:
+    """
+    Set up the three mocks needed to simulate a template file in Storage.
+
+    Mocks _list_files_in_sync_actions, creates a real temp file with `content`,
+    and mocks _download_file_from_storage_api to return its path.
+    """
+    comp._list_files_in_sync_actions = MagicMock(return_value=[{"id": 1, "name": "template.txt"}])
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(content)
+        tmp_path = f.name
+    comp._download_file_from_storage_api = MagicMock(return_value=tmp_path)
+
+
+@contextmanager
+def make_component_for_validate_config(config: dict, image_parameters: dict = None):
+    """
+    Build a Component for validate_config() tests with sub-validators pre-mocked to SUCCESS.
+
+    All base validators are mocked so tests can focus on routing logic by overriding
+    specific validators or asserting on call counts.
+    """
+    comp = Component.__new__(Component)
+    comp.cfg = Configuration.load_from_dict(config)
+
+    mock_env = MagicMock()
+    mock_env.stack_id = "connection.keboola.com"
+    mock_env.token = None
+    comp.environment_variables = mock_env
+
+    table1 = MagicMock()
+    table1.destination = "email_basis.csv"
+    table1.source = "out.c-bucket.email_basis"
+
+    mock_conf = MagicMock()
+    mock_conf.tables_input_mapping = [table1]
+    mock_conf.action = "validate_config"
+    mock_conf.image_parameters = image_parameters or {}
+
+    with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+        mock_conf_prop.return_value = mock_conf
+
+        comp.test_smtp_server_connection_ = MagicMock(return_value=_make_success())
+        comp.validate_subject_ = MagicMock(return_value=_make_success())
+        comp.validate_plaintext_template_ = MagicMock(return_value=_make_success())
+        comp.validate_html_template_ = MagicMock(return_value=_make_success())
+        comp.validate_attachments_ = MagicMock(return_value=_make_success())
+        comp.validate_single_table_ = MagicMock(return_value=_make_success())
+        comp._return_table_path = MagicMock(return_value=None)
+
+        yield comp
+
+
+def _make_success():
+    from keboola.component.sync_actions import MessageType, ValidationResult
+
+    return ValidationResult("✅ OK", MessageType.SUCCESS)
+
+
+def _make_danger(msg: str = "❌ Something failed"):
+    from keboola.component.sync_actions import MessageType, ValidationResult
+
+    return ValidationResult(msg, MessageType.DANGER)
+
+
 # ==================== Tests for _validate_run_configuration() ====================
 
 
@@ -151,26 +273,14 @@ class TestValidateRunConfiguration:
 
     def test_basic_mode_skips_validation(self, component):
         """Basic mode should skip all validation."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                configuration_type="basic",
-            )
-        )
-        # Should not raise
+        component.cfg = Configuration.load_from_dict(make_advanced_config(configuration_type="basic"))
         component._validate_run_configuration()
-
-    # Data Preview Validation
 
     def test_single_table_missing_source_table(self, component):
         """Single table mode without source table specified should raise."""
         component.cfg = Configuration.load_from_dict(
             make_advanced_config(
-                advanced_options={
-                    "attachments_config": {
-                        "attachments_source": "single_table",
-                        "source_table": None,
-                    }
-                }
+                advanced_options={"attachments_config": {"attachments_source": "single_table", "source_table": None}}
             )
         )
         with pytest.raises(UserException, match="Source table must be specified"):
@@ -208,56 +318,29 @@ class TestValidateRunConfiguration:
         with pytest.raises(UserException, match="At least one option must be enabled"):
             component._validate_run_configuration()
 
-    def test_single_table_with_csv_sample_only(self, component):
-        """Single table mode with only CSV sample enabled should pass."""
+    @pytest.mark.parametrize(
+        "include_csv_sample, include_snapshot_link",
+        [
+            pytest.param(True, False, id="csv_sample_only"),
+            pytest.param(False, True, id="snapshot_link_only"),
+            pytest.param(True, True, id="both_toggles"),
+        ],
+    )
+    def test_single_table_valid_toggle_combinations(self, component, include_csv_sample, include_snapshot_link):
+        """Single table mode should pass when at least one output toggle is enabled."""
         component.cfg = Configuration.load_from_dict(
             make_advanced_config(
                 advanced_options={
                     "attachments_config": {
                         "attachments_source": "single_table",
                         "source_table": "email_export.csv",
-                        "include_csv_sample": True,
-                        "include_snapshot_link": False,
+                        "include_csv_sample": include_csv_sample,
+                        "include_snapshot_link": include_snapshot_link,
                     }
                 }
             )
         )
-        # Should not raise
-        component._validate_run_configuration()
-
-    def test_single_table_with_snapshot_link_only(self, component):
-        """Single table mode with only snapshot link enabled should pass."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "attachments_config": {
-                        "attachments_source": "single_table",
-                        "source_table": "email_export.csv",
-                        "include_csv_sample": False,
-                        "include_snapshot_link": True,
-                    }
-                }
-            )
-        )
-        # Should not raise
-        component._validate_run_configuration()
-
-    def test_single_table_with_both_toggles(self, component):
-        """Single table mode with both CSV sample and snapshot link enabled should pass."""
-        component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "attachments_config": {
-                        "attachments_source": "single_table",
-                        "source_table": "email_export.csv",
-                        "include_csv_sample": True,
-                        "include_snapshot_link": True,
-                    }
-                }
-            )
-        )
-        # Should not raise
-        component._validate_run_configuration()
+        component._validate_run_configuration()  # should not raise
 
     @pytest.mark.parametrize(
         "config_override",
@@ -270,19 +353,12 @@ class TestValidateRunConfiguration:
     def test_data_preview_not_active_skips_validation(self, component, config_override):
         """Data preview validation skipped when not active."""
         component.cfg = Configuration.load_from_dict(make_advanced_config(**config_override))
-        # Should not raise even without data_preview_table
-        component._validate_run_configuration()
+        component._validate_run_configuration()  # should not raise
 
     def test_unknown_attachments_source(self, component):
         """Unknown attachment source value (e.g., legacy 'data_preview') should raise clear error."""
         component.cfg = Configuration.load_from_dict(
-            make_advanced_config(
-                advanced_options={
-                    "attachments_config": {
-                        "attachments_source": "data_preview",  # Legacy value
-                    }
-                }
-            )
+            make_advanced_config(advanced_options={"attachments_config": {"attachments_source": "data_preview"}})
         )
         with pytest.raises(
             UserException,
@@ -368,8 +444,79 @@ class TestLoadAttachmentTables:
         result = Component._load_attachment_tables(mock_input_tables, "nonexistent.csv")
         assert "email_basis.csv" in result
         assert "email_export.csv" in result
-        # Verify the values are the full paths
         assert result["email_basis.csv"] == "/data/in/tables/email_basis.csv"
+
+
+# ==================== Tests for _return_table_path() ====================
+
+
+class TestReturnTablePath:
+    """Tests for the _return_table_path() method.
+
+    This method has two branches:
+    - action == "run": resolves table path from in-memory input table definitions
+    - any other action (sync actions): delegates to _download_table_from_storage_api()
+
+    Critical regression guard: the "run" branch must match by
+    Path(table.full_path).name (e.g. "email_basis.csv"), NOT by table.name
+    (e.g. "email_basis" — the Keboola storage table name, which has no extension).
+    Using table.name would silently return None for every lookup.
+    """
+
+    @contextmanager
+    def _make_component(self, action: str):
+        """Build a minimal Component with mocked configuration.action."""
+        comp = Component.__new__(Component)
+
+        table1 = MagicMock()
+        table1.name = "email_basis"  # storage table name — no .csv extension
+        table1.full_path = "/data/in/tables/email_basis.csv"
+
+        table2 = MagicMock()
+        table2.name = "email_export_dataset"  # storage table name — no .csv extension
+        table2.full_path = "/data/in/tables/email_export.csv"
+
+        mock_conf = MagicMock()
+        mock_conf.action = action
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_conf
+            comp.get_input_tables_definitions = MagicMock(return_value=[table1, table2])
+            comp._download_table_from_storage_api = MagicMock(return_value="/tmp/downloaded.csv")
+            comp._mock_conf = mock_conf
+            yield comp
+
+    @pytest.mark.parametrize(
+        "table_name, expected_path",
+        [
+            pytest.param("email_basis.csv", "/data/in/tables/email_basis.csv", id="first_table"),
+            pytest.param("email_export.csv", "/data/in/tables/email_export.csv", id="second_table"),
+        ],
+    )
+    def test_run_action_matches_by_filename(self, table_name, expected_path):
+        """action=run: table is found by filename (Path(full_path).name), not by table.name.
+
+        REGRESSION GUARD: if the code used `table.name == table_name` instead of
+        `Path(table.full_path).name == table_name`, this test fails because
+        table.name="email_basis" != "email_basis.csv".
+        """
+        with self._make_component("run") as comp:
+            result = comp._return_table_path(table_name)
+        assert result == expected_path
+
+    def test_run_action_not_found_returns_none(self):
+        """action=run: table name not in input tables → returns None (no exception)."""
+        with self._make_component("run") as comp:
+            result = comp._return_table_path("nonexistent.csv")
+        assert result is None
+
+    def test_sync_action_delegates_to_storage_api(self):
+        """action=validate_config (any non-run): calls _download_table_from_storage_api, not get_input_tables_definitions."""
+        with self._make_component("validate_config") as comp:
+            result = comp._return_table_path("email_basis.csv")
+        assert result == "/tmp/downloaded.csv"
+        comp._download_table_from_storage_api.assert_called_once_with("email_basis.csv")
+        comp.get_input_tables_definitions.assert_not_called()
 
 
 # ==================== Tests for validate_single_table_() Sync Action ====================
@@ -403,18 +550,20 @@ class TestValidateSingleTableSyncAction:
             },
         }
 
-    def test_missing_source_table(self, base_config, mock_tables_mapping):
-        """Should return error when source_table is not set."""
+    def _run(self, base_config, mock_tables_mapping) -> object:
+        """Build a minimal Component and run validate_single_table_(), returning the result."""
         comp = Component.__new__(Component)
         comp.cfg = Configuration.load_from_dict(base_config)
         mock_config = MagicMock()
         mock_config.parameters = base_config
         mock_config.tables_input_mapping = mock_tables_mapping
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as p:
+            p.return_value = mock_config
+            return comp.validate_single_table_()
 
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            result = comp.validate_single_table_()
-
+    def test_missing_source_table(self, base_config, mock_tables_mapping):
+        """Should return error when source_table is not set."""
+        result = self._run(base_config, mock_tables_mapping)
         assert "❌ Source table must be specified for single table mode" in result.message
         assert result.type.name == "ERROR"
 
@@ -422,115 +571,766 @@ class TestValidateSingleTableSyncAction:
         """Should return error when source_table doesn't exist in input tables."""
         base_config["advanced_options"]["attachments_config"]["source_table"] = "nonexistent.csv"
         base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = True
-
-        comp = Component.__new__(Component)
-        comp.cfg = Configuration.load_from_dict(base_config)
-        mock_config = MagicMock()
-        mock_config.parameters = base_config
-        mock_config.tables_input_mapping = mock_tables_mapping
-
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            result = comp.validate_single_table_()
-
+        result = self._run(base_config, mock_tables_mapping)
         assert "❌" in result.message
         assert "nonexistent.csv" in result.message
         assert result.type.name == "ERROR"
 
     def test_neither_toggle_enabled(self, base_config, mock_tables_mapping):
-        """Should return error when both include_csv_sample and include_snapshot_link are False."""
+        """Should return error when both toggles are False."""
         base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
-        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = False
-        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = False
-
-        comp = Component.__new__(Component)
-        comp.cfg = Configuration.load_from_dict(base_config)
-        mock_config = MagicMock()
-        mock_config.parameters = base_config
-        mock_config.tables_input_mapping = mock_tables_mapping
-
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            result = comp.validate_single_table_()
-
+        result = self._run(base_config, mock_tables_mapping)
         assert "❌ At least one option must be enabled" in result.message
         assert result.type.name == "ERROR"
 
     def test_multiple_errors_shown_together(self, base_config, mock_tables_mapping):
         """Should show all errors at once (not fail-fast)."""
-        # Missing source_table AND neither toggle enabled
-        base_config["advanced_options"]["attachments_config"]["source_table"] = None
-        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = False
-        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = False
-
-        comp = Component.__new__(Component)
-        comp.cfg = Configuration.load_from_dict(base_config)
-        mock_config = MagicMock()
-        mock_config.parameters = base_config
-        mock_config.tables_input_mapping = mock_tables_mapping
-
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            result = comp.validate_single_table_()
-
-        # Both errors should be present
+        # source_table=None AND both toggles False → two errors
+        result = self._run(base_config, mock_tables_mapping)
         assert "❌ Source table must be specified for single table mode" in result.message
         assert "❌ At least one option must be enabled" in result.message
         assert result.type.name == "ERROR"
 
-    def test_csv_sample_only_valid(self, base_config, mock_tables_mapping):
-        """Should succeed when only include_csv_sample is enabled."""
+    @pytest.mark.parametrize(
+        "include_csv_sample, include_snapshot_link",
+        [
+            pytest.param(True, False, id="csv_only"),
+            pytest.param(False, True, id="snapshot_only"),
+            pytest.param(True, True, id="both"),
+        ],
+    )
+    def test_valid_toggle_combinations(
+        self, base_config, mock_tables_mapping, include_csv_sample, include_snapshot_link
+    ):
+        """Should succeed when source_table exists and at least one toggle is enabled."""
         base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
-        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = True
-        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = False
-
-        comp = Component.__new__(Component)
-        comp.cfg = Configuration.load_from_dict(base_config)
-        mock_config = MagicMock()
-        mock_config.parameters = base_config
-        mock_config.tables_input_mapping = mock_tables_mapping
-
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            result = comp.validate_single_table_()
-
+        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = include_csv_sample
+        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = include_snapshot_link
+        result = self._run(base_config, mock_tables_mapping)
         assert "✅" in result.message
         assert result.type.name == "SUCCESS"
 
-    def test_snapshot_link_only_valid(self, base_config, mock_tables_mapping):
-        """Should succeed when only include_snapshot_link is enabled."""
-        base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
-        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = False
-        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = True
 
-        comp = Component.__new__(Component)
-        comp.cfg = Configuration.load_from_dict(base_config)
-        mock_config = MagicMock()
-        mock_config.parameters = base_config
-        mock_config.tables_input_mapping = mock_tables_mapping
+# ==================== Tests for _parse_template_placeholders() ====================
 
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            result = comp.validate_single_table_()
 
-        assert "✅" in result.message
+class TestParseTemplatePlaceholders:
+    @pytest.mark.parametrize(
+        "template, expected",
+        [
+            pytest.param(None, set(), id="none"),
+            pytest.param("", set(), id="empty_string"),
+            pytest.param("Hello world", set(), id="no_placeholders"),
+            pytest.param("Hello {{name}}", {"name"}, id="single_placeholder"),
+            pytest.param("Hi {{name}}, your order {{order_id}} is ready", {"name", "order_id"}, id="multiple"),
+            pytest.param("{{name}} and {{name}} again", {"name"}, id="duplicates_deduplicated"),
+        ],
+    )
+    def test_parse_template_placeholders(self, template, expected):
+        assert Component._parse_template_placeholders(template) == expected
+
+
+# ==================== Tests for validate_subject_() ====================
+
+
+class TestValidateSubject:
+    # --- from_table ---
+
+    def test_from_table_column_exists(self):
+        """subject_source=from_table, column present in table → success."""
+        config = make_advanced_config(
+            advanced_options={"subject_config": {"subject_source": "from_table", "subject_column": "subject"}}
+        )
+        with make_component_for_sync(config, table_csv="recipient_email,subject\ntest@example.com,Hello\n") as comp:
+            result = comp.validate_subject_()
+        assert result.message == "✅ Subject column exists in the input table"
         assert result.type.name == "SUCCESS"
 
-    def test_both_toggles_enabled_valid(self, base_config, mock_tables_mapping):
-        """Should succeed when both toggles are enabled."""
-        base_config["advanced_options"]["attachments_config"]["source_table"] = "email_basis.csv"
-        base_config["advanced_options"]["attachments_config"]["include_csv_sample"] = True
-        base_config["advanced_options"]["attachments_config"]["include_snapshot_link"] = True
+    @pytest.mark.parametrize("column_value", [None, ""], ids=["none", "empty_string"])
+    def test_from_table_column_not_specified(self, column_value):
+        """subject_source=from_table, column None or empty → not specified error."""
+        config = make_advanced_config(
+            advanced_options={"subject_config": {"subject_source": "from_table", "subject_column": column_value}}
+        )
+        with make_component_for_sync(config) as comp:
+            result = comp.validate_subject_()
+        assert result.message == "❌ Subject column is not specified"
+        assert result.type.name == "ERROR"
 
-        comp = Component.__new__(Component)
-        comp.cfg = Configuration.load_from_dict(base_config)
-        mock_config = MagicMock()
-        mock_config.parameters = base_config
-        mock_config.tables_input_mapping = mock_tables_mapping
+    def test_from_table_column_missing_from_csv(self):
+        """subject_source=from_table, column exists but cell templates reference missing columns → error."""
+        config = make_advanced_config(
+            advanced_options={"subject_config": {"subject_source": "from_table", "subject_column": "subject"}}
+        )
+        with make_component_for_sync(
+            config, table_csv="recipient_email,subject\ntest@example.com,{{nonexistent}}\n"
+        ) as comp:
+            result = comp.validate_subject_()
+        assert "❌" in result.message
+        assert result.type.name == "ERROR"
 
-        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
-            mock_conf_prop.return_value = mock_config
-            result = comp.validate_single_table_()
+    @pytest.mark.parametrize("table_name", [None, ""], ids=["none", "empty_string"])
+    def test_from_table_email_data_table_not_specified(self, table_name):
+        """subject_source=from_table, email_data_table_name None or empty → table not specified error."""
+        config = make_advanced_config(
+            advanced_options={
+                "email_data_table_name": table_name,
+                "subject_config": {"subject_source": "from_table", "subject_column": "subject"},
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            result = comp.validate_subject_()
+        assert result.message == "❌ Email data table is not specified"
+        assert result.type.name == "ERROR"
 
-        assert "✅" in result.message
+    def test_from_table_column_not_in_csv_headers(self):
+        """subject_source=from_table, subject_column name absent from CSV headers → unhandled KeyError (bug).
+
+        BUG: _get_missing_columns_from_table does row[column] without checking if the column exists
+        as a header, so a misconfigured column name raises KeyError instead of returning a clean
+        validation error. This test documents the current broken behavior.
+        """
+        config = make_advanced_config(
+            advanced_options={"subject_config": {"subject_source": "from_table", "subject_column": "nonexistent_col"}}
+        )
+        with make_component_for_sync(config, table_csv="recipient_email,subject\ntest@example.com,Hello\n") as comp:
+            with pytest.raises(KeyError, match="nonexistent_col"):
+                comp.validate_subject_()
+
+    # --- from_template_definition ---
+
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param("Hello world", id="no_placeholders"),
+            pytest.param(None, id="none"),
+            pytest.param("", id="empty_string"),
+        ],
+    )
+    def test_template_no_placeholders(self, template):
+        """subject_source=from_template_definition, no placeholders in template → no placeholders message."""
+        config = make_advanced_config(
+            advanced_options={
+                "subject_config": {
+                    "subject_source": "from_template_definition",
+                    "subject_template_definition": template,
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            result = comp.validate_subject_()
+        assert result.message == "✅ Subject has no placeholders to validate"
         assert result.type.name == "SUCCESS"
+
+    def test_template_with_valid_placeholders(self):
+        """subject_source=from_template_definition, placeholders match columns → success."""
+        config = make_advanced_config(
+            advanced_options={
+                "subject_config": {
+                    "subject_source": "from_template_definition",
+                    "subject_template_definition": "Hello {{name}}",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            comp._load_table_columns = MagicMock(return_value=["name", "email"])
+            result = comp.validate_subject_()
+        assert result.message == "✅ All subject placeholders are present in the input table"
+        assert result.type.name == "SUCCESS"
+
+    def test_template_with_invalid_placeholders(self):
+        """subject_source=from_template_definition, placeholder not in columns → missing columns error."""
+        config = make_advanced_config(
+            advanced_options={
+                "subject_config": {
+                    "subject_source": "from_template_definition",
+                    "subject_template_definition": "Order {{order_id}} ready",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            comp._load_table_columns = MagicMock(return_value=["name", "email"])
+            result = comp.validate_subject_()
+        assert result.type.name == "ERROR"
+        assert "❌ Missing columns:" in result.message
+        assert "order_id" in result.message
+
+    def test_template_columns_not_accessible(self):
+        """subject_source=from_template_definition, Storage API fails → cannot validate error."""
+        from keboola.component.sync_actions import MessageType, ValidationResult
+
+        config = make_advanced_config(
+            advanced_options={
+                "subject_config": {
+                    "subject_source": "from_template_definition",
+                    "subject_template_definition": "Hello {{name}}",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            comp._load_table_columns = MagicMock(
+                return_value=ValidationResult("Couldn't fetch columns", MessageType.DANGER)
+            )
+            result = comp.validate_subject_()
+        assert result.type.name == "ERROR"
+        assert "❌ Cannot validate placeholders: email data table is not accessible" in result.message
+
+
+# ==================== Tests for validate_plaintext_template_() / validate_html_template_() ====================
+
+
+class TestValidateTemplate:
+    """Tests for _validate_template() via validate_plaintext_template_() and validate_html_template_().
+
+    All tests are parametrized over plaintext=True/False so the same scenarios are
+    verified for both the plaintext and HTML template validators.
+    """
+
+    def _call(self, comp, plaintext: bool):
+        return comp.validate_plaintext_template_() if plaintext else comp.validate_html_template_()
+
+    def _col_key(self, plaintext: bool) -> str:
+        return "plaintext_template_column" if plaintext else "html_template_column"
+
+    def _def_key(self, plaintext: bool) -> str:
+        return "plaintext_template_definition" if plaintext else "html_template_definition"
+
+    def _file_key(self, plaintext: bool) -> str:
+        return "plaintext_template_filename" if plaintext else "html_template_filename"
+
+    # --- from_table ---
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_from_table_column_exists(self, plaintext):
+        """message_body_source=from_table, template column present → success."""
+        expected = (
+            "✅ Plaintext template column exists in the input table"
+            if plaintext
+            else "✅ HTML template column exists in the input table"
+        )
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_table",
+                    "use_html_template": not plaintext,
+                    self._col_key(plaintext): "body_col",
+                }
+            }
+        )
+        with make_component_for_sync(config, table_csv="recipient_email,body_col\ntest@example.com,Hello\n") as comp:
+            result = self._call(comp, plaintext)
+        assert result.message == expected
+        assert result.type.name == "SUCCESS"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    @pytest.mark.parametrize("column_value", [None, ""], ids=["none", "empty_string"])
+    def test_from_table_column_not_specified(self, plaintext, column_value):
+        """message_body_source=from_table, column None or empty → not specified error."""
+        expected = (
+            "❌ Plaintext template column is not specified" if plaintext else "❌ HTML template column is not specified"
+        )
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_table",
+                    "use_html_template": not plaintext,
+                    self._col_key(plaintext): column_value,
+                }
+            }
+        )
+        with make_component_for_sync(config, table_csv="recipient_email,body_col\ntest@example.com,Hello\n") as comp:
+            result = self._call(comp, plaintext)
+        assert result.message == expected
+        assert result.type.name == "ERROR"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    @pytest.mark.parametrize("table_name", [None, ""], ids=["none", "empty_string"])
+    def test_from_table_email_data_table_not_specified(self, plaintext, table_name):
+        """message_body_source=from_table, email_data_table_name None or empty → table not specified error."""
+        config = make_advanced_config(
+            advanced_options={
+                "email_data_table_name": table_name,
+                "message_body_config": {
+                    "message_body_source": "from_table",
+                    "use_html_template": not plaintext,
+                    self._col_key(plaintext): "body_col",
+                },
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            result = self._call(comp, plaintext)
+        assert result.message == "❌ Email data table is not specified"
+        assert result.type.name == "ERROR"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_from_table_column_not_in_csv_headers(self, plaintext):
+        """message_body_source=from_table, column name absent from CSV headers → unhandled KeyError (bug).
+
+        BUG: same root cause as TestValidateSubject.test_from_table_column_not_in_csv_headers —
+        _get_missing_columns_from_table does row[column] without checking fieldnames first.
+        """
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_table",
+                    "use_html_template": not plaintext,
+                    self._col_key(plaintext): "nonexistent_col",
+                }
+            }
+        )
+        with make_component_for_sync(config, table_csv="recipient_email,body\ntest@example.com,Hello\n") as comp:
+            with pytest.raises(KeyError, match="nonexistent_col"):
+                self._call(comp, plaintext)
+
+    # --- from_template_definition ---
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param("Hello world, no placeholders here.", id="no_placeholders"),
+            pytest.param(None, id="none"),
+        ],
+    )
+    def test_definition_no_placeholders(self, plaintext, template):
+        """message_body_source=from_template_definition, no placeholders in template → no placeholders message."""
+        expected = (
+            "✅ Plaintext template has no placeholders to validate"
+            if plaintext
+            else "✅ HTML template has no placeholders to validate"
+        )
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_definition",
+                    "use_html_template": not plaintext,
+                    self._def_key(plaintext): template,
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            result = self._call(comp, plaintext)
+        assert result.message == expected
+        assert result.type.name == "SUCCESS"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_definition_with_valid_placeholders(self, plaintext):
+        """message_body_source=from_template_definition, placeholders match columns → success."""
+        expected = (
+            "✅ All plaintext template placeholders are present in the input table"
+            if plaintext
+            else "✅ All HTML template placeholders are present in the input table"
+        )
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_definition",
+                    "use_html_template": not plaintext,
+                    self._def_key(plaintext): "Hello {{name}}",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            comp._load_table_columns = MagicMock(return_value=["name", "email"])
+            result = self._call(comp, plaintext)
+        assert result.message == expected
+        assert result.type.name == "SUCCESS"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_definition_with_invalid_placeholders(self, plaintext):
+        """message_body_source=from_template_definition, placeholder not in columns → missing columns error."""
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_definition",
+                    "use_html_template": not plaintext,
+                    self._def_key(plaintext): "Hello {{nonexistent}}",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            comp._load_table_columns = MagicMock(return_value=["name", "email"])
+            result = self._call(comp, plaintext)
+        assert result.type.name == "ERROR"
+        assert "❌ Missing columns:" in result.message
+        assert "nonexistent" in result.message
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_definition_columns_not_accessible(self, plaintext):
+        """message_body_source=from_template_definition, Storage API fails → cannot validate error."""
+        from keboola.component.sync_actions import MessageType, ValidationResult
+
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_definition",
+                    "use_html_template": not plaintext,
+                    self._def_key(plaintext): "Hello {{name}}",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            comp._load_table_columns = MagicMock(
+                return_value=ValidationResult("Couldn't fetch columns", MessageType.DANGER)
+            )
+            result = self._call(comp, plaintext)
+        assert result.type.name == "ERROR"
+        assert "❌ Cannot validate placeholders: email data table is not accessible" in result.message
+
+    # --- from_template_file ---
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    @pytest.mark.parametrize("filename", [None, ""], ids=["none", "empty_string"])
+    def test_file_filename_not_specified(self, plaintext, filename):
+        """message_body_source=from_template_file, filename None or empty → not specified error."""
+        expected = (
+            "❌ Plaintext template filename is not specified"
+            if plaintext
+            else "❌ HTML template filename is not specified"
+        )
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_file",
+                    "use_html_template": not plaintext,
+                    self._file_key(plaintext): filename,
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            result = self._call(comp, plaintext)
+        assert result.message == expected
+        assert result.type.name == "ERROR"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_file_no_placeholders(self, plaintext):
+        """message_body_source=from_template_file, file has no placeholders → no placeholders message."""
+        expected = (
+            "✅ Plaintext template has no placeholders to validate"
+            if plaintext
+            else "✅ HTML template has no placeholders to validate"
+        )
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_file",
+                    "use_html_template": not plaintext,
+                    self._file_key(plaintext): "template.txt",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            _mock_template_file(comp, "Hello world, no placeholders.")
+            result = self._call(comp, plaintext)
+        assert result.message == expected
+        assert result.type.name == "SUCCESS"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_file_with_valid_placeholders(self, plaintext):
+        """message_body_source=from_template_file, file has valid placeholders → success."""
+        expected = (
+            "✅ All plaintext template placeholders are present in the input table"
+            if plaintext
+            else "✅ All HTML template placeholders are present in the input table"
+        )
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_file",
+                    "use_html_template": not plaintext,
+                    self._file_key(plaintext): "template.txt",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            _mock_template_file(comp, "Hello {{name}}")
+            comp._load_table_columns = MagicMock(return_value=["name", "email"])
+            result = self._call(comp, plaintext)
+        assert result.message == expected
+        assert result.type.name == "SUCCESS"
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_file_with_invalid_placeholders(self, plaintext):
+        """message_body_source=from_template_file, file has placeholder not in columns → error."""
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_file",
+                    "use_html_template": not plaintext,
+                    self._file_key(plaintext): "template.txt",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            _mock_template_file(comp, "Hello {{nonexistent}}")
+            comp._load_table_columns = MagicMock(return_value=["name", "email"])
+            result = self._call(comp, plaintext)
+        assert result.type.name == "ERROR"
+        assert "❌ Missing columns:" in result.message
+        assert "nonexistent" in result.message
+
+    @pytest.mark.parametrize("plaintext", [True, False])
+    def test_file_columns_not_accessible(self, plaintext):
+        """message_body_source=from_template_file, Storage API fails for columns → cannot validate error."""
+        from keboola.component.sync_actions import MessageType, ValidationResult
+
+        config = make_advanced_config(
+            advanced_options={
+                "message_body_config": {
+                    "message_body_source": "from_template_file",
+                    "use_html_template": not plaintext,
+                    self._file_key(plaintext): "template.txt",
+                }
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            _mock_template_file(comp, "Hello {{name}}")
+            comp._load_table_columns = MagicMock(
+                return_value=ValidationResult("Couldn't fetch columns", MessageType.DANGER)
+            )
+            result = self._call(comp, plaintext)
+        assert result.type.name == "ERROR"
+        assert "❌ Cannot validate placeholders: email data table is not accessible" in result.message
+
+
+# ==================== Tests for validate_attachments_() ====================
+
+
+class TestValidateAttachments:
+    @pytest.mark.parametrize("column_value", [None, ""], ids=["none", "empty_string"])
+    def test_from_table_column_not_specified(self, column_value):
+        """attachments_source=from_table, column None or empty → not specified error."""
+        config = make_advanced_config(
+            advanced_options={
+                "attachments_config": {"attachments_source": "from_table", "attachments_column": column_value}
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            result = comp.validate_attachments_()
+        assert result.message == "❌ Attachments column is not specified"
+        assert result.type.name == "ERROR"
+
+    @pytest.mark.parametrize("table_name", [None, ""], ids=["none", "empty_string"])
+    def test_from_table_email_data_table_not_specified(self, table_name):
+        """attachments_source=from_table, email_data_table_name None or empty → table not specified error."""
+        config = make_advanced_config(
+            advanced_options={
+                "email_data_table_name": table_name,
+                "attachments_config": {"attachments_source": "from_table", "attachments_column": "attachments"},
+            }
+        )
+        with make_component_for_sync(config) as comp:
+            result = comp.validate_attachments_()
+        assert result.message == "❌ Email data table is not specified"
+        assert result.type.name == "ERROR"
+
+    def test_from_table_invalid_json(self):
+        """attachments_source=from_table, column contains non-JSON data → clear error."""
+        config = make_advanced_config(
+            advanced_options={
+                "attachments_config": {"attachments_source": "from_table", "attachments_column": "recipient_email"}
+            }
+        )
+        with make_component_for_sync(config, table_csv="recipient_email,body\ntest@example.com,Hello\n") as comp:
+            comp._list_files_in_sync_actions = MagicMock(return_value=[])
+            result = comp.validate_attachments_()
+        assert "❌" in result.message
+        assert "recipient_email" in result.message
+        assert "valid JSON" in result.message
+        assert result.type.name == "ERROR"
+
+    def test_from_table_valid(self):
+        """attachments_source=from_table, valid JSON column with matching files → success."""
+        config = make_advanced_config(
+            advanced_options={
+                "attachments_config": {"attachments_source": "from_table", "attachments_column": "attachments"}
+            }
+        )
+        csv = 'recipient_email,attachments\ntest@example.com,"[""report.pdf""]"\n'
+        with make_component_for_sync(config, table_csv=csv) as comp:
+            comp._list_files_in_sync_actions = MagicMock(return_value=[{"name": "report.pdf", "id": 1}])
+            result = comp.validate_attachments_()
+        assert result.message == "✅ All attachments are present"
+        assert result.type.name == "SUCCESS"
+
+    def test_from_table_missing_attachments(self):
+        """attachments_source=from_table, JSON column references files not in Storage → missing attachments error."""
+        config = make_advanced_config(
+            advanced_options={
+                "attachments_config": {"attachments_source": "from_table", "attachments_column": "attachments"}
+            }
+        )
+        csv = 'recipient_email,attachments\ntest@example.com,"[""missing.pdf""]"\n'
+        with make_component_for_sync(config, table_csv=csv) as comp:
+            comp._list_files_in_sync_actions = MagicMock(return_value=[])
+            result = comp.validate_attachments_()
+        assert result.type.name == "ERROR"
+        assert "❌ Missing attachments:" in result.message
+        assert "missing.pdf" in result.message
+
+    def test_all_input_files_skips_validation(self):
+        """attachments_source=all_input_files → from_table branch skipped, returns success."""
+        config = make_advanced_config(
+            advanced_options={"attachments_config": {"attachments_source": "all_input_files"}}
+        )
+        with make_component_for_sync(config) as comp:
+            result = comp.validate_attachments_()
+        assert result.message == "✅ All attachments are present"
+        assert result.type.name == "SUCCESS"
+
+
+# ==================== Tests for validate_config() ====================
+
+
+class TestValidateConfig:
+    """Tests for the validate_config() sync action method."""
+
+    @pytest.mark.parametrize("column_value", [None, ""], ids=["none", "empty_string"])
+    def test_recipient_column_not_specified(self, column_value):
+        """recipient_email_address_column None or empty → early return with error."""
+        config = make_advanced_config(advanced_options={"recipient_email_address_column": column_value})
+        with make_component_for_sync(config) as comp:
+            result = comp.validate_config()
+        assert result.message == "❌ Recipient email address column is not specified"
+        assert result.type.name == "ERROR"
+
+    def test_full_validation_all_pass(self):
+        """All three base sub-validators SUCCESS → aggregated SUCCESS with messages joined by double newline."""
+        config = make_advanced_config(advanced_options={"include_attachments": False})
+        with make_component_for_validate_config(config) as comp:
+            result = comp.validate_config()
+
+        assert result.type.name == "SUCCESS"
+        comp.test_smtp_server_connection_.assert_called_once()
+        comp.validate_subject_.assert_called_once()
+        comp.validate_plaintext_template_.assert_called_once()
+        assert result.message == "\n\n".join(["✅ OK", "✅ OK", "✅ OK"])
+
+    def test_full_validation_one_sub_validator_fails(self):
+        """One sub-validator returns DANGER → aggregated result is DANGER."""
+        config = make_advanced_config(advanced_options={"include_attachments": False})
+        with make_component_for_validate_config(config) as comp:
+            comp.validate_subject_ = MagicMock(return_value=_make_danger("❌ Subject column is not specified"))
+            result = comp.validate_config()
+
+        assert result.type.name == "ERROR"
+        assert "❌ Subject column is not specified" in result.message
+
+    def test_html_template_enabled_adds_html_validator(self):
+        """use_html_template=True → validate_html_template_ included in chain (4 validators total)."""
+        config = make_advanced_config(
+            advanced_options={
+                "include_attachments": False,
+                "message_body_config": {
+                    "message_body_source": "from_template_definition",
+                    "use_html_template": True,
+                    "plaintext_template_definition": "Hello",
+                    "html_template_definition": "Hello HTML",
+                },
+            }
+        )
+        with make_component_for_validate_config(config) as comp:
+            result = comp.validate_config()
+
+        assert result.type.name == "SUCCESS"
+        comp.validate_html_template_.assert_called_once()
+        assert result.message.count("✅ OK") == 4
+
+    def test_html_template_disabled_skips_html_validator(self):
+        """use_html_template=False → validate_html_template_ not called."""
+        config = make_advanced_config(advanced_options={"include_attachments": False})
+        with make_component_for_validate_config(config) as comp:
+            result = comp.validate_config()
+
+        comp.validate_html_template_.assert_not_called()
+        assert result.type.name == "SUCCESS"
+
+    def test_unknown_attachments_source_early_return(self):
+        """attachments_source is unrecognized → early return DANGER before validators run."""
+        config = make_advanced_config(
+            advanced_options={
+                "include_attachments": True,
+                "attachments_config": {"attachments_source": "data_preview"},
+            }
+        )
+        with make_component_for_validate_config(config) as comp:
+            result = comp.validate_config()
+
+        assert result.type.name == "ERROR"
+        assert "❌ Unknown attachment source: 'data_preview'" in result.message
+        comp.validate_attachments_.assert_not_called()
+        comp.validate_single_table_.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "advanced_options, image_parameters, expect_attachments_called, expect_single_table_called",
+        [
+            pytest.param(
+                {"include_attachments": False},
+                None,
+                False,
+                False,
+                id="include_attachments=False",
+            ),
+            pytest.param(
+                {
+                    "include_attachments": True,
+                    "attachments_config": {"attachments_source": "from_table", "attachments_column": "attachments"},
+                },
+                {"disable_attachments": True},
+                False,
+                False,
+                id="disable_attachments_stack_override",
+            ),
+            pytest.param(
+                {
+                    "include_attachments": True,
+                    "attachments_config": {
+                        "attachments_source": "single_table",
+                        "source_table": "email_basis.csv",
+                        "include_csv_sample": True,
+                    },
+                },
+                None,
+                False,
+                True,
+                id="source=single_table",
+            ),
+            pytest.param(
+                {
+                    "include_attachments": True,
+                    "attachments_config": {"attachments_source": "from_table", "attachments_column": "attachments"},
+                },
+                None,
+                True,
+                False,
+                id="source=from_table",
+            ),
+            pytest.param(
+                {
+                    "include_attachments": True,
+                    "attachments_config": {"attachments_source": "all_input_files"},
+                },
+                None,
+                False,
+                False,
+                id="source=all_input_files",
+            ),
+        ],
+    )
+    def test_attachment_validator_routing(
+        self, advanced_options, image_parameters, expect_attachments_called, expect_single_table_called
+    ):
+        """Correct attachment validators included/excluded based on config and stack overrides."""
+        config = make_advanced_config(advanced_options=advanced_options)
+        with make_component_for_validate_config(config, image_parameters=image_parameters) as comp:
+            comp.validate_config()
+
+        if expect_attachments_called:
+            comp.validate_attachments_.assert_called_once()
+        else:
+            comp.validate_attachments_.assert_not_called()
+
+        if expect_single_table_called:
+            comp.validate_single_table_.assert_called_once()
+        else:
+            comp.validate_single_table_.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -113,6 +113,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -162,8 +171,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -180,8 +191,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.15.0" },
+    { name = "ty", specifier = ">=0.0.20" },
 ]
 
 [[package]]
@@ -249,6 +262,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
 ]
 
 [[package]]
@@ -355,6 +386,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/84/376a3b96e5a8d33a7aa2c5b3b31a4b3c364117184bf0b17418055f6ace66/identify-2.6.17.tar.gz", hash = "sha256:f816b0b596b204c9fdf076ded172322f2723cf958d02f9c3587504834c8ff04d", size = 99579, upload-time = "2026-03-01T20:04:12.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl", hash = "sha256:be5f8412d5ed4b20f2bd41a65f920990bdccaa6a4a18a08f1eefdcd0bdd885f0", size = 99382, upload-time = "2026-03-01T20:04:11.439Z" },
 ]
 
 [[package]]
@@ -483,6 +523,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "o365"
 version = "2.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -509,12 +558,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
 ]
 
 [[package]]
@@ -664,6 +738,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/bb/93a3e83bdf9322c7e21cafd092e56a4a17c4d8ef4277b6eb01af1a540a6f/python_discovery-1.1.0.tar.gz", hash = "sha256:447941ba1aed8cc2ab7ee3cb91be5fc137c5bdbb05b7e6ea62fbdcb66e50b268", size = 55674, upload-time = "2026-02-26T09:42:49.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/54/82a6e2ef37f0f23dccac604b9585bdcbd0698604feb64807dcb72853693e/python_discovery-1.1.0-py3-none-any.whl", hash = "sha256:a162893b8809727f54594a99ad2179d2ede4bf953e12d4c7abc3cc9cdbd1437b", size = 30687, upload-time = "2026-02-26T09:42:48.548Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -796,6 +883,30 @@ wheels = [
 ]
 
 [[package]]
+name = "ty"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/95/8de69bb98417227b01f1b1d743c819d6456c9fd140255b6124b05b17dfd6/ty-0.0.20.tar.gz", hash = "sha256:ebba6be7974c14efbb2a9adda6ac59848f880d7259f089dfa72a093039f1dcc6", size = 5262529, upload-time = "2026-03-02T15:51:36.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/2c/718abe48393e521bf852cd6b0f984766869b09c258d6e38a118768a91731/ty-0.0.20-py3-none-linux_armv6l.whl", hash = "sha256:7cc12769c169c9709a829c2248ee2826b7aae82e92caeac813d856f07c021eae", size = 10333656, upload-time = "2026-03-02T15:51:56.461Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0e/eb1c4cc4a12862e2327b72657bcebb10b7d9f17046f1bdcd6457a0211615/ty-0.0.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3b777c1bf13bc0a95985ebb8a324b8668a4a9b2e514dde5ccf09e4d55d2ff232", size = 10168505, upload-time = "2026-03-02T15:51:51.895Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7f/10230798e673f0dd3094dfd16e43bfd90e9494e7af6e8e7db516fb431ddf/ty-0.0.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b2a4a7db48bf8cba30365001bc2cad7fd13c1a5aacdd704cc4b7925de8ca5eb3", size = 9678510, upload-time = "2026-03-02T15:51:48.451Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/3d/59d9159577494edd1728f7db77b51bb07884bd21384f517963114e3ab5f6/ty-0.0.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6846427b8b353a43483e9c19936dc6a25612573b44c8f7d983dfa317e7f00d4c", size = 10162926, upload-time = "2026-03-02T15:51:40.558Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a8/b7273eec3e802f78eb913fbe0ce0c16ef263723173e06a5776a8359b2c66/ty-0.0.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:245ceef5bd88df366869385cf96411cb14696334f8daa75597cf7e41c3012eb8", size = 10171702, upload-time = "2026-03-02T15:51:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/32/5f1144f2f04a275109db06e3498450c4721554215b80ae73652ef412eeab/ty-0.0.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c4d21d1cdf67a444d3c37583c17291ddba9382a9871021f3f5d5735e09e85efe", size = 10682552, upload-time = "2026-03-02T15:51:33.102Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/db/9f1f637310792f12bd6ed37d5fc8ab39ba1a9b0c6c55a33865e9f1cad840/ty-0.0.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bd4ffd907d1bd70e46af9e9a2f88622f215e1bf44658ea43b32c2c0b357299e4", size = 11242605, upload-time = "2026-03-02T15:51:34.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/68/cc9cae2e732fcfd20ccdffc508407905a023fc8493b8771c392d915528dc/ty-0.0.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6594b58d8b0e9d16a22b3045fc1305db4b132c8d70c17784ab8c7a7cc986807", size = 10974655, upload-time = "2026-03-02T15:51:46.011Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c1/b9e3e3f28fe63486331e653f6aeb4184af8b1fe80542fcf74d2dda40a93d/ty-0.0.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3662f890518ce6cf4d7568f57d03906912d2afbf948a01089a28e325b1ef198c", size = 10761325, upload-time = "2026-03-02T15:51:26.818Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9e/67db935bdedf219a00fb69ec5437ba24dab66e0f2e706dd54a4eca234b84/ty-0.0.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e3ffbae58f9f0d17cdc4ac6d175ceae560b7ed7d54f9ddfb1c9f31054bcdc2c", size = 10145793, upload-time = "2026-03-02T15:51:38.562Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/b0eb815d4dc5a819c7e4faddc2a79058611169f7eef07ccc006531ce228c/ty-0.0.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:176e52bc8bb00b0e84efd34583962878a447a3a0e34ecc45fd7097a37554261b", size = 10189640, upload-time = "2026-03-02T15:51:50.202Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/71/63734923965cbb70df1da3e93e4b8875434e326b89e9f850611122f279bf/ty-0.0.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b2bc73025418e976ca4143dde71fb9025a90754a08ac03e6aa9b80d4bed1294b", size = 10370568, upload-time = "2026-03-02T15:51:42.295Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a0/a532c2048533347dff48e9ca98bd86d2c224356e101688a8edaf8d6973fb/ty-0.0.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52f7c9ec6e363e094b3c389c344d5a140401f14a77f0625e3f28c21918552f5", size = 10853999, upload-time = "2026-03-02T15:51:58.963Z" },
+    { url = "https://files.pythonhosted.org/packages/48/88/36c652c658fe96658043e4abc8ea97801de6fb6e63ab50aaa82807bff1d8/ty-0.0.20-py3-none-win32.whl", hash = "sha256:c7d32bfe93f8fcaa52b6eef3f1b930fd7da410c2c94e96f7412c30cfbabf1d17", size = 9744206, upload-time = "2026-03-02T15:51:54.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a7/a4a13bed1d7fd9d97aaa3c5bb5e6d3e9a689e6984806cbca2ab4c9233cac/ty-0.0.20-py3-none-win_amd64.whl", hash = "sha256:a5e10f40fc4a0a1cbcb740a4aad5c7ce35d79f030836ea3183b7a28f43170248", size = 10711999, upload-time = "2026-03-02T15:51:29.212Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/7e/6bfd748a9f4ff9267ed3329b86a0f02cdf6ab49f87bc36c8a164852f99fc/ty-0.0.20-py3-none-win_arm64.whl", hash = "sha256:53f7a5c12c960e71f160b734f328eff9a35d578af4b67a36b0bb5990ac5cdc27", size = 10150143, upload-time = "2026-03-02T15:51:31.283Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -832,6 +943,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Bug fixes

- **Table path lookup #2** (`ef2eedd`) — second occurrence of `table.name` vs `Path(table.full_path).name` bug missed in fd1751a, silently returning `None` for table path resolution
- **`Path.rename()` crash** (`7c8d356`) — called as a class method instead of an instance method, crashing attachment file loading at runtime
- **Legacy attachment config regression** (`37f0d49`) — strict validation of `attachments_source` raised `UserException("Unknown attachment source: 'None'")` on configs that never configured attachments but had `include_attachments` defaulting to `True`. Broke 3 production projects running daily. Fix: silently skip when `attachments_source` is falsy, only error on genuinely invalid values. Extracted `VALID_ATTACHMENT_SOURCES` constant used in both validation locations.

## Improvements

- **Config validation messages** — corrected and added missing sync action error/success strings
- **Test suite** — extended to 119 unit tests covering config validation, table path resolution, attachment source edge cases (falsy values, unknown values)
- **Pre-commit hooks** — ruff format, ruff lint, pytest, ty type check (warning-only); Claude Code startup script under `.claude/`
- **CI** — branch image tags always include the GitHub run number