### PR TITLE
feat(CFTL-478): add CC and BCC email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@
 
 It allows user to send specific subject and message body with or without attachments to a list of recipients
 
-- **Recipient Email Addresses** - comma delimited list of email addresses
+- **Recipient Email Addresses (To)** - comma delimited list of email addresses
+- **CC Email Addresses** - (optional) comma delimited list of CC email addresses
+- **BCC Email Addresses** - (optional) comma delimited list of BCC email addresses
 - **Subject** - subject literal
 - **Message Body** - message body literal
 - **Include Attachments** - checkbox indicating, whether to attach files and table in input mapping
@@ -44,7 +46,9 @@ As opposed to the basic configuration option you need to provide table with **Re
 It lets you choose from multiple sourcing options for subject, message body and attachments. It enables user to include html message body version with the plaintext version as a backup
 
 - **Email Data Table Name** - dynamically loaded selection of the table containing recipient email addresses, subject and message body template placeholder values and custom attachment filenames (if selected)
-- **Recipient Email Address Column** - Recipient email address column name
+- **Recipient Email Address Column (To)** - Recipient email address column name
+- **CC Column** - (optional) Column containing CC email addresses (comma or semicolon separated)
+- **BCC Column** - (optional) Column containing BCC email addresses (comma or semicolon separated)
 
 - **Subject Config**
  - **Subject Source** - `From Table`, `From Template Definition`
@@ -99,6 +103,8 @@ It lets you choose from multiple sourcing options for subject, message body and 
  
  - `status` - `OK` or `ERROR`
  - `recipient_email_address` - recipient_email_address
+ - `cc_email_addresses` - CC email addresses (if configured)
+ - `bcc_email_addresses` - BCC email addresses (if configured)
  - `sender_email_address` - sender_email_address
  - `subject` - subject
  - `plaintext_message_body` - plaintext_message_body

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 It allows user to send specific subject and message body with or without attachments to a list of recipients
 
 - **Recipient Email Addresses (To)** - comma delimited list of email addresses
-- **CC Email Addresses** - (optional) comma delimited list of CC email addresses
-- **BCC Email Addresses** - (optional) comma delimited list of BCC email addresses
+- **Cc Email Addresses** - (optional) comma delimited list of Cc email addresses
+- **Bcc Email Addresses** - (optional) comma delimited list of Bcc email addresses
 - **Subject** - subject literal
 - **Message Body** - message body literal
 - **Include Attachments** - checkbox indicating, whether to attach files and table in input mapping
@@ -47,8 +47,8 @@ It lets you choose from multiple sourcing options for subject, message body and 
 
 - **Email Data Table Name** - dynamically loaded selection of the table containing recipient email addresses, subject and message body template placeholder values and custom attachment filenames (if selected)
 - **Recipient Email Address Column (To)** - Recipient email address column name
-- **CC Column** - (optional) Column containing CC email addresses (comma or semicolon separated)
-- **BCC Column** - (optional) Column containing BCC email addresses (comma or semicolon separated)
+- **Cc Column** - (optional) Column containing Cc email addresses (comma or semicolon separated)
+- **Bcc Column** - (optional) Column containing Bcc email addresses (comma or semicolon separated)
 
 - **Subject Config**
  - **Subject Source** - `From Table`, `From Template Definition`
@@ -103,8 +103,8 @@ It lets you choose from multiple sourcing options for subject, message body and 
  
  - `status` - `OK` or `ERROR`
  - `recipient_email_address` - recipient_email_address
- - `cc_email_addresses` - CC email addresses (if configured)
- - `bcc_email_addresses` - BCC email addresses (if configured)
+ - `cc_email_addresses` - Cc email addresses (if configured)
+ - `bcc_email_addresses` - Bcc email addresses (if configured)
  - `sender_email_address` - sender_email_address
  - `subject` - subject
  - `plaintext_message_body` - plaintext_message_body

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -2,11 +2,21 @@
   "type": "object",
   "title": "SMTP sender configuration",
   "properties": {
+    "send_to_all_recipients": {
+      "type": "boolean",
+      "format": "checkbox",
+      "title": "Send as Single Email (enables Cc and Bcc fields)",
+      "default": false,
+      "propertyOrder": 1,
+      "options": {
+        "tooltip": "When checked, all To addresses are grouped into a single email — Cc and Bcc fields become available, working just like composing a message in Outlook. When unchecked (default), each To address receives its own individual email."
+      }
+    },
     "configuration_type": {
       "title": "Configuration Type",
       "type": "string",
       "enum": ["basic", "advanced"],
-      "propertyOrder": 1,
+      "propertyOrder": 2,
       "options": {
         "enum_titles": ["Basic", "Advanced"]
       }
@@ -14,14 +24,14 @@
     "basic_options": {
       "title": "Basic Options",
       "type": "object",
-      "propertyOrder": 2,
+      "propertyOrder": 3,
       "options": {"dependencies": {"configuration_type": "basic"}},
       "properties": {
         "recipient_email_addresses": {
           "title": "Recipient Email Addresses (To)",
           "type": "string",
           "options": {
-            "tooltip": "Enter one or more email addresses separated by commas or semicolons.\nUse the **Send to All Recipients** checkbox to control whether they receive one shared email or individual separate emails."
+            "tooltip": "Enter one or more email addresses separated by commas or semicolons.\nUse the **Send as Single Email** checkbox to control whether they receive one shared email or individual separate emails."
           },
           "propertyOrder": 1
         },
@@ -29,20 +39,22 @@
           "title": "CC Email Addresses",
           "type": "string",
           "options": {
-            "tooltip": "Enter one or more CC email addresses separated by commas or semicolons. These recipients will receive a copy of the email and will be visible to all other recipients."
+            "tooltip": "Enter one or more CC email addresses separated by commas or semicolons. These recipients will receive a copy of the email and will be visible to all other recipients.",
+            "dependencies": {"send_to_all_recipients": true}
           },
-          "propertyOrder": 1.1
+          "propertyOrder": 2
         },
         "bcc_email_addresses": {
           "title": "BCC Email Addresses",
           "type": "string",
           "options": {
-            "tooltip": "Enter one or more BCC email addresses separated by commas or semicolons. These recipients will receive a copy of the email but will not be visible to other recipients."
+            "tooltip": "Enter one or more BCC email addresses separated by commas or semicolons. BCC recipients are hidden from To and CC recipients by the mail server.",
+            "dependencies": {"send_to_all_recipients": true}
           },
-          "propertyOrder": 1.2
+          "propertyOrder": 3
         },
         "subject": {
-          "propertyOrder": 2,
+          "propertyOrder": 4,
           "type": "string",
           "title": "Subject",
           "default": "Example subject",
@@ -52,7 +64,7 @@
           }
         },
         "message_body": {
-          "propertyOrder": 3,
+          "propertyOrder": 5,
           "type": "string",
           "title": "Message Body",
           "default": "Example message body.",
@@ -67,7 +79,7 @@
           "format": "checkbox",
           "description": "If checked, all tables and files in input mapping will be used as attachments.",
           "default": true,
-          "propertyOrder": 4
+          "propertyOrder": 6
         }
       }
     },
@@ -75,7 +87,7 @@
       "title": "Advanced Options",
       "type": "object",
       "format": "grid-strict",
-      "propertyOrder": 3,
+      "propertyOrder": 4,
       "options": {"dependencies": {"configuration_type": "advanced"}},
       "properties": {
         "email_data_table_name": {
@@ -99,9 +111,9 @@
             "tooltip": "Name of the table with recipient email addresses, placeholders, and other columns depending on your configuration."
           }
         },
-        "recipient_email_address_column": {
+        "cc_email_address_column": {
           "type": "string",
-          "title": "Recipient Column (To)",
+          "title": "CC Column",
           "items": {
             "enum": [],
             "type": "string"
@@ -116,12 +128,14 @@
               "action": "load_input_table_columns",
               "autoload": ["parameters.advanced_options.email_data_table_name"]
             },
-            "grid_columns": 4
+            "grid_columns": 6,
+            "tooltip": "Optional column containing CC email addresses (comma or semicolon separated). Recipients will be visible to all.",
+            "dependencies": {"send_to_all_recipients": true}
           }
         },
-        "cc_email_address_column": {
+        "recipient_email_address_column": {
           "type": "string",
-          "title": "CC Column",
+          "title": "Recipient Column (To)",
           "items": {
             "enum": [],
             "type": "string"
@@ -129,16 +143,14 @@
           "enum": [],
           "format": "select",
           "uniqueItems": true,
-          "propertyOrder": 2.1,
+          "propertyOrder": 3,
           "options": {
-            "tags": true,
             "async": {
               "label": "Re-load columns",
               "action": "load_input_table_columns",
               "autoload": ["parameters.advanced_options.email_data_table_name"]
             },
-            "grid_columns": 4,
-            "tooltip": "Optional column containing CC email addresses (comma or semicolon separated). Recipients will be visible to all."
+            "grid_columns": 6
           }
         },
         "bcc_email_address_column": {
@@ -151,23 +163,23 @@
           "enum": [],
           "format": "select",
           "uniqueItems": true,
-          "propertyOrder": 2.2,
+          "propertyOrder": 4,
           "options": {
-            "tags": true,
             "async": {
               "label": "Re-load columns",
               "action": "load_input_table_columns",
               "autoload": ["parameters.advanced_options.email_data_table_name"]
             },
-            "grid_columns": 4,
-            "tooltip": "Optional column containing BCC email addresses (comma or semicolon separated). Recipients will not be visible to others."
+            "grid_columns": 6,
+            "tooltip": "Optional column containing BCC email addresses (comma or semicolon separated). BCC recipients are hidden from To and CC recipients by the mail server.",
+            "dependencies": {"send_to_all_recipients": true}
           }
         },
         "subject_config": {
           "title": "Subject",
           "type": "object",
           "format": "grid-strict",
-          "propertyOrder": 3,
+          "propertyOrder": 5,
           "options": {
             "grid_columns": 12
           },
@@ -235,7 +247,7 @@
           "title": "Message Body",
           "type": "object",
           "format": "grid-strict",
-          "propertyOrder": 4,
+          "propertyOrder": 6,
           "options": {
             "grid_columns": 12
           },
@@ -391,7 +403,7 @@
           "title": "Attach Data",
           "format": "checkbox",
           "default": true,
-          "propertyOrder": 5,
+          "propertyOrder": 7,
           "options": {
             "grid_columns": 12
           }
@@ -400,7 +412,7 @@
           "title": "Data Options",
           "type": "object",
           "format": "grid-strict",
-          "propertyOrder": 6,
+          "propertyOrder": 8,
           "options": {
             "grid_columns": 12,
             "dependencies": {
@@ -598,14 +610,6 @@
           }
         }
       }
-    },
-    "send_to_all_recipients": {
-      "type": "boolean",
-      "format": "checkbox",
-      "title": "Send to All Recipients in Single Email",
-      "description": "If checked, all recipient addresses (separated by commas or semicolons) are grouped into a single email with all recipients visible in the To field. If unchecked (default), each address receives its own separate email.",
-      "default": false,
-      "propertyOrder": 6
     },
     "dry_run": {
       "type": "boolean",

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -36,19 +36,19 @@
           "propertyOrder": 1
         },
         "cc_email_addresses": {
-          "title": "CC Email Addresses",
+          "title": "Cc Email Addresses",
           "type": "string",
           "options": {
-            "tooltip": "Enter one or more CC email addresses separated by commas or semicolons. These recipients will receive a copy of the email and will be visible to all other recipients.",
+            "tooltip": "Enter one or more Cc email addresses separated by commas or semicolons. These recipients will receive a copy of the email and will be visible to all other recipients.",
             "dependencies": {"send_to_all_recipients": true}
           },
           "propertyOrder": 2
         },
         "bcc_email_addresses": {
-          "title": "BCC Email Addresses",
+          "title": "Bcc Email Addresses",
           "type": "string",
           "options": {
-            "tooltip": "Enter one or more BCC email addresses separated by commas or semicolons. BCC recipients are hidden from To and CC recipients by the mail server.",
+            "tooltip": "Enter one or more Bcc email addresses separated by commas or semicolons. Bcc recipients are hidden from To and Cc recipients by the mail server.",
             "dependencies": {"send_to_all_recipients": true}
           },
           "propertyOrder": 3
@@ -113,7 +113,7 @@
         },
         "cc_email_address_column": {
           "type": "string",
-          "title": "CC Column",
+          "title": "Cc Column",
           "items": {
             "enum": [],
             "type": "string"
@@ -129,7 +129,7 @@
               "autoload": ["parameters.advanced_options.email_data_table_name"]
             },
             "grid_columns": 6,
-            "tooltip": "Optional column containing CC email addresses (comma or semicolon separated). Recipients will be visible to all.",
+            "tooltip": "Optional column containing Cc email addresses (comma or semicolon separated). Recipients will be visible to all.",
             "dependencies": {"send_to_all_recipients": true}
           }
         },
@@ -155,7 +155,7 @@
         },
         "bcc_email_address_column": {
           "type": "string",
-          "title": "BCC Column",
+          "title": "Bcc Column",
           "items": {
             "enum": [],
             "type": "string"
@@ -171,7 +171,7 @@
               "autoload": ["parameters.advanced_options.email_data_table_name"]
             },
             "grid_columns": 6,
-            "tooltip": "Optional column containing BCC email addresses (comma or semicolon separated). BCC recipients are hidden from To and CC recipients by the mail server.",
+            "tooltip": "Optional column containing Bcc email addresses (comma or semicolon separated). Bcc recipients are hidden from To and Cc recipients by the mail server.",
             "dependencies": {"send_to_all_recipients": true}
           }
         },

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -18,12 +18,28 @@
       "options": {"dependencies": {"configuration_type": "basic"}},
       "properties": {
         "recipient_email_addresses": {
-          "title": "Recipient Email Addresses",
+          "title": "Recipient Email Addresses (To)",
           "type": "string",
           "options": {
             "tooltip": "Enter one or more email addresses separated by commas or semicolons.\nUse the **Send to All Recipients** checkbox to control whether they receive one shared email or individual separate emails."
           },
           "propertyOrder": 1
+        },
+        "cc_email_addresses": {
+          "title": "CC Email Addresses",
+          "type": "string",
+          "options": {
+            "tooltip": "Enter one or more CC email addresses separated by commas or semicolons. These recipients will receive a copy of the email and will be visible to all other recipients."
+          },
+          "propertyOrder": 1.1
+        },
+        "bcc_email_addresses": {
+          "title": "BCC Email Addresses",
+          "type": "string",
+          "options": {
+            "tooltip": "Enter one or more BCC email addresses separated by commas or semicolons. These recipients will receive a copy of the email but will not be visible to other recipients."
+          },
+          "propertyOrder": 1.2
         },
         "subject": {
           "propertyOrder": 2,
@@ -85,7 +101,7 @@
         },
         "recipient_email_address_column": {
           "type": "string",
-          "title": "Recipient Column",
+          "title": "Recipient Column (To)",
           "items": {
             "enum": [],
             "type": "string"
@@ -100,7 +116,51 @@
               "action": "load_input_table_columns",
               "autoload": ["parameters.advanced_options.email_data_table_name"]
             },
-            "grid_columns": 6
+            "grid_columns": 4
+          }
+        },
+        "cc_email_address_column": {
+          "type": "string",
+          "title": "CC Column",
+          "items": {
+            "enum": [],
+            "type": "string"
+          },
+          "enum": [],
+          "format": "select",
+          "uniqueItems": true,
+          "propertyOrder": 2.1,
+          "options": {
+            "tags": true,
+            "async": {
+              "label": "Re-load columns",
+              "action": "load_input_table_columns",
+              "autoload": ["parameters.advanced_options.email_data_table_name"]
+            },
+            "grid_columns": 4,
+            "tooltip": "Optional column containing CC email addresses (comma or semicolon separated). Recipients will be visible to all."
+          }
+        },
+        "bcc_email_address_column": {
+          "type": "string",
+          "title": "BCC Column",
+          "items": {
+            "enum": [],
+            "type": "string"
+          },
+          "enum": [],
+          "format": "select",
+          "uniqueItems": true,
+          "propertyOrder": 2.2,
+          "options": {
+            "tags": true,
+            "async": {
+              "label": "Re-load columns",
+              "action": "load_input_table_columns",
+              "autoload": ["parameters.advanced_options.email_data_table_name"]
+            },
+            "grid_columns": 4,
+            "tooltip": "Optional column containing BCC email addresses (comma or semicolon separated). Recipients will not be visible to others."
           }
         },
         "subject_config": {

--- a/src/client.py
+++ b/src/client.py
@@ -115,6 +115,8 @@ class SMTPClient:
         rendered_html_message: Union[str, None] = None,
         attachments_paths_by_filename: Dict[str, str] = None,
         parse_multiple_recipients: bool = False,
+        cc_email_address: Union[str, None] = None,
+        bcc_email_address: Union[str, None] = None,
     ) -> MIMEMultipart:
         """
         Prepares email message including html version (if selected) and adds attachments (if they exist).
@@ -123,14 +125,24 @@ class SMTPClient:
         comma/semicolon-separated addresses and all are included in the To header as a
         comma-separated list (per RFC 2822) so a single email is sent to all recipients.
         When False (default), the string is used as-is for a single recipient.
+
+        cc_email_address and bcc_email_address are optional comma/semicolon-separated strings.
+        All addresses in Cc and Bcc are validated against the address whitelist if configured.
         """
         if parse_multiple_recipients:
             parsed_addresses = self._parse_recipient_addresses(recipient_email_address)
         else:
             parsed_addresses = [recipient_email_address.strip()]
 
+        parsed_cc = self._parse_recipient_addresses(cc_email_address) if cc_email_address else []
+        parsed_bcc = self._parse_recipient_addresses(bcc_email_address) if bcc_email_address else []
+
         if self.address_whitelist:
             for addr in parsed_addresses:
+                self.check_email_mask(addr)
+            for addr in parsed_cc:
+                self.check_email_mask(addr)
+            for addr in parsed_bcc:
                 self.check_email_mask(addr)
 
         # Format To header as comma-separated list per RFC 2822
@@ -139,6 +151,10 @@ class SMTPClient:
         email_ = MIMEMultipart("mixed")
         email_["From"] = self.sender_email_address
         email_["To"] = formatted_to
+        if parsed_cc:
+            email_["Cc"] = ", ".join(parsed_cc)
+        if parsed_bcc:
+            email_["Bcc"] = ", ".join(parsed_bcc)
         email_["Subject"] = subject
 
         email_message = MIMEMultipart("alternative")
@@ -223,6 +239,14 @@ class SMTPClient:
         # Add each recipient individually so O365/Microsoft Graph API handles them correctly
         for addr in self._parse_recipient_addresses(email["To"]):
             email_.to.add(addr)
+
+        if email["Cc"]:
+            for addr in self._parse_recipient_addresses(email["Cc"]):
+                email_.cc.add(addr)
+
+        if email["Bcc"]:
+            for addr in self._parse_recipient_addresses(email["Bcc"]):
+                email_.bcc.add(addr)
 
         email_.subject = email["Subject"]
         email_.body = html_message_body if html_message_body is not None else message_body

--- a/src/component.py
+++ b/src/component.py
@@ -41,6 +41,8 @@ VALID_ATTACHMENT_SOURCES = ("all_input_files", "from_table", "single_table")
 RESULT_TABLE_COLUMNS = (
     "status",
     "recipient_email_address",
+    "cc_email_addresses",
+    "bcc_email_addresses",
     "sender_email_address",
     "subject",
     "plaintext_message_body",
@@ -64,6 +66,8 @@ VALID_ATTACHMENTS_MESSAGE = "✅ All attachments are present"
 general_error_row = {
     "status": "ERROR",
     "recipient_email_address": "",
+    "cc_email_addresses": "",
+    "bcc_email_addresses": "",
     "sender_email_address": "",
     "subject": "",
     "plaintext_message_body": "",
@@ -414,14 +418,22 @@ class Component(ComponentBase):
         for row in reader:
             try:
                 recipient_email_address = row
+                cc_email_address = None
+                bcc_email_address = None
                 if isinstance(reader, csv.DictReader):
                     recipient_email_address = row[advanced_options.recipient_email_address_column]
+                    if advanced_options.cc_email_address_column:
+                        cc_email_address = row.get(advanced_options.cc_email_address_column) or None
+                    if advanced_options.bcc_email_address_column:
+                        bcc_email_address = row.get(advanced_options.bcc_email_address_column) or None
 
                 if not use_advanced_options:
                     rendered_subject = basic_options.subject
                     rendered_plaintext_message = basic_options.message_body
                     rendered_html_message = None
                     custom_attachments_paths_by_filename = attachments_paths_by_filename
+                    cc_email_address = basic_options.cc_email_addresses or None
+                    bcc_email_address = basic_options.bcc_email_addresses or None
                 else:
                     if subject_column is not None:
                         subject_template_text = row[subject_column]
@@ -494,15 +506,19 @@ class Component(ComponentBase):
                     rendered_plaintext_message=rendered_plaintext_message,
                     rendered_html_message=rendered_html_message,
                     parse_multiple_recipients=self.cfg.send_to_all_recipients,
+                    cc_email_address=cc_email_address,
+                    bcc_email_address=bcc_email_address,
                 )
 
                 status = "OK"
                 error_message = ""
                 if not dry_run:
                     try:
+                        cc_log = f" cc=`{email_['Cc']}`" if email_["Cc"] else ""
+                        bcc_log = f" bcc=`{email_['Bcc']}`" if email_["Bcc"] else ""
                         logging.info(
                             f"Sending email with subject: `{email_['Subject']}`"
-                            f" from `{email_['From']}` to `{email_['To']}`"
+                            f" from `{email_['From']}` to `{email_['To']}`{cc_log}{bcc_log}"
                         )
 
                         if not self.cfg.advanced_options.include_attachments or self._client.disable_attachments:
@@ -536,6 +552,8 @@ class Component(ComponentBase):
                     dict(
                         status=status,
                         recipient_email_address=email_["To"],
+                        cc_email_addresses=email_["Cc"] or "",
+                        bcc_email_addresses=email_["Bcc"] or "",
                         sender_email_address=email_["From"],
                         subject=email_["Subject"],
                         plaintext_message_body=rendered_plaintext_message,

--- a/src/component.py
+++ b/src/component.py
@@ -217,6 +217,15 @@ class Component(ComponentBase):
         Should be called after configuration is loaded and before actual work begins.
         Skips validation for basic mode.
         """
+        if not self.cfg.send_to_all_recipients:
+            has_cc = self.cfg.basic_options.cc_email_addresses or self.cfg.advanced_options.cc_email_address_column
+            has_bcc = self.cfg.basic_options.bcc_email_addresses or self.cfg.advanced_options.bcc_email_address_column
+            if has_cc or has_bcc:
+                raise UserException(
+                    "Cc and Bcc are only available when 'Send as Single Email' is enabled. "
+                    "Either enable single-email mode or remove Cc/Bcc from the configuration."
+                )
+
         # Skip validation in basic mode
         if self.cfg.configuration_type == "basic":
             return

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -97,6 +97,8 @@ class BasicEmailOptions(ConfigurationBase):
     """
 
     recipient_email_addresses: Union[str, None] = None
+    cc_email_addresses: Union[str, None] = None
+    bcc_email_addresses: Union[str, None] = None
     subject: Union[str, None] = None
     message_body: Union[str, None] = None
     include_attachments: Union[bool, None] = None
@@ -162,6 +164,8 @@ class AttachmentsConfig(ConfigurationBase):
 class AdvancedEmailOptions(ConfigurationBase):
     email_data_table_name: Union[str, None] = None
     recipient_email_address_column: Union[str, None] = None
+    cc_email_address_column: Union[str, None] = None
+    bcc_email_address_column: Union[str, None] = None
     subject_config: SubjectConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
     message_body_config: MessageBodyConfig = dataclasses.field(default_factory=lambda: ConfigTree({}))
     include_attachments: bool = True

--- a/tests/test_cc_bcc.py
+++ b/tests/test_cc_bcc.py
@@ -1,10 +1,10 @@
 """
-Tests for CC and BCC email support.
+Tests for Cc and Bcc email support.
 
 Covers:
 - SMTPClient.build_email() with cc_email_address and bcc_email_address parameters
-- Address whitelist validation for CC and BCC recipients
-- O365 send path with CC and BCC recipients
+- Address whitelist validation for Cc and Bcc recipients
+- O365 send path with Cc and Bcc recipients
 """
 
 from unittest.mock import MagicMock, patch
@@ -31,14 +31,14 @@ def _make_client(**overrides) -> SMTPClient:
         return SMTPClient(**defaults)
 
 
-# ==================== Tests for build_email with CC/BCC ====================
+# ==================== Tests for build_email with Cc/Bcc ====================
 
 
 class TestBuildEmailCcBcc:
     """Tests for build_email() with cc_email_address and bcc_email_address parameters."""
 
     def test_no_cc_bcc_by_default(self):
-        """Without CC/BCC params, headers should not be set."""
+        """Without Cc/Bcc params, headers should not be set."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="user@example.com",
@@ -50,7 +50,7 @@ class TestBuildEmailCcBcc:
         assert email["Bcc"] is None
 
     def test_cc_single_address(self):
-        """Single CC address should be set in Cc header."""
+        """Single Cc address should be set in Cc header."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="to@example.com",
@@ -63,7 +63,7 @@ class TestBuildEmailCcBcc:
         assert email["Bcc"] is None
 
     def test_bcc_single_address(self):
-        """Single BCC address should be set in Bcc header."""
+        """Single Bcc address should be set in Bcc header."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="to@example.com",
@@ -76,7 +76,7 @@ class TestBuildEmailCcBcc:
         assert email["Bcc"] == "bcc@example.com"
 
     def test_cc_multiple_addresses(self):
-        """Multiple CC addresses (comma-separated) should be parsed and formatted."""
+        """Multiple Cc addresses (comma-separated) should be parsed and formatted."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="to@example.com",
@@ -87,7 +87,7 @@ class TestBuildEmailCcBcc:
         assert email["Cc"] == "cc1@example.com, cc2@example.com"
 
     def test_bcc_multiple_addresses_semicolon(self):
-        """Multiple BCC addresses (semicolon-separated) should be parsed and formatted."""
+        """Multiple Bcc addresses (semicolon-separated) should be parsed and formatted."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="to@example.com",
@@ -98,7 +98,7 @@ class TestBuildEmailCcBcc:
         assert email["Bcc"] == "bcc1@example.com, bcc2@example.com"
 
     def test_cc_and_bcc_together(self):
-        """Both CC and BCC can be set simultaneously."""
+        """Both Cc and Bcc can be set simultaneously."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="to@example.com",
@@ -112,7 +112,7 @@ class TestBuildEmailCcBcc:
         assert email["Bcc"] == "bcc@example.com"
 
     def test_empty_cc_bcc_strings_not_set(self):
-        """Empty strings for CC/BCC should not set headers."""
+        """Empty strings for Cc/Bcc should not set headers."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="to@example.com",
@@ -125,14 +125,14 @@ class TestBuildEmailCcBcc:
         assert email["Bcc"] is None
 
 
-# ==================== Tests for whitelist validation with CC/BCC ====================
+# ==================== Tests for whitelist validation with Cc/Bcc ====================
 
 
 class TestWhitelistCcBcc:
-    """Tests for address whitelist validation on CC and BCC recipients."""
+    """Tests for address whitelist validation on Cc and Bcc recipients."""
 
     def test_cc_allowed_by_whitelist(self):
-        """CC address matching whitelist should not raise."""
+        """Cc address matching whitelist should not raise."""
         client = _make_client(address_whitelist=["*@allowed.com"])
         email = client.build_email(
             recipient_email_address="to@allowed.com",
@@ -143,7 +143,7 @@ class TestWhitelistCcBcc:
         assert email["Cc"] == "cc@allowed.com"
 
     def test_cc_rejected_by_whitelist(self):
-        """CC address not matching whitelist should raise UserException."""
+        """Cc address not matching whitelist should raise UserException."""
         client = _make_client(address_whitelist=["*@allowed.com"])
         with pytest.raises(UserException, match="does not match any of the allowed masks"):
             client.build_email(
@@ -154,7 +154,7 @@ class TestWhitelistCcBcc:
             )
 
     def test_bcc_allowed_by_whitelist(self):
-        """BCC address matching whitelist should not raise."""
+        """Bcc address matching whitelist should not raise."""
         client = _make_client(address_whitelist=["*@allowed.com"])
         email = client.build_email(
             recipient_email_address="to@allowed.com",
@@ -165,7 +165,7 @@ class TestWhitelistCcBcc:
         assert email["Bcc"] == "bcc@allowed.com"
 
     def test_bcc_rejected_by_whitelist(self):
-        """BCC address not matching whitelist should raise UserException."""
+        """Bcc address not matching whitelist should raise UserException."""
         client = _make_client(address_whitelist=["*@allowed.com"])
         with pytest.raises(UserException, match="does not match any of the allowed masks"):
             client.build_email(
@@ -176,7 +176,7 @@ class TestWhitelistCcBcc:
             )
 
     def test_multiple_cc_one_rejected(self):
-        """If one CC address in a multi-address string is disallowed, it should raise."""
+        """If one Cc address in a multi-address string is disallowed, it should raise."""
         client = _make_client(address_whitelist=["*@allowed.com"])
         with pytest.raises(UserException, match="does not match any of the allowed masks"):
             client.build_email(
@@ -187,7 +187,7 @@ class TestWhitelistCcBcc:
             )
 
     def test_multiple_bcc_one_rejected(self):
-        """If one BCC address in a multi-address string is disallowed, it should raise."""
+        """If one Bcc address in a multi-address string is disallowed, it should raise."""
         client = _make_client(address_whitelist=["*@allowed.com"])
         with pytest.raises(UserException, match="does not match any of the allowed masks"):
             client.build_email(
@@ -198,7 +198,7 @@ class TestWhitelistCcBcc:
             )
 
     def test_no_whitelist_allows_all_cc_bcc(self):
-        """Without whitelist, any CC/BCC addresses should be accepted."""
+        """Without whitelist, any Cc/Bcc addresses should be accepted."""
         client = _make_client()
         email = client.build_email(
             recipient_email_address="to@any.com",
@@ -211,14 +211,14 @@ class TestWhitelistCcBcc:
         assert email["Bcc"] == "bcc@any.com"
 
 
-# ==================== Tests for O365 with CC/BCC ====================
+# ==================== Tests for O365 with Cc/Bcc ====================
 
 
 class TestO365CcBcc:
-    """Tests for send_email_via_o365_oauth() with CC and BCC recipients."""
+    """Tests for send_email_via_o365_oauth() with Cc and Bcc recipients."""
 
     def test_o365_cc_added(self):
-        """CC recipients should be added via cc.add() on O365 message."""
+        """Cc recipients should be added via cc.add() on O365 message."""
         client = _make_client()
         mock_message = MagicMock()
         mock_account = MagicMock()
@@ -239,7 +239,7 @@ class TestO365CcBcc:
         assert cc_calls == ["cc1@example.com", "cc2@example.com"]
 
     def test_o365_bcc_added(self):
-        """BCC recipients should be added via bcc.add() on O365 message."""
+        """Bcc recipients should be added via bcc.add() on O365 message."""
         client = _make_client()
         mock_message = MagicMock()
         mock_account = MagicMock()
@@ -260,7 +260,7 @@ class TestO365CcBcc:
         assert bcc_calls == ["bcc1@example.com", "bcc2@example.com"]
 
     def test_o365_no_cc_bcc_when_not_set(self):
-        """Without CC/BCC, cc.add() and bcc.add() should not be called."""
+        """Without Cc/Bcc, cc.add() and bcc.add() should not be called."""
         client = _make_client()
         mock_message = MagicMock()
         mock_account = MagicMock()
@@ -279,7 +279,7 @@ class TestO365CcBcc:
         mock_message.bcc.add.assert_not_called()
 
     def test_o365_cc_and_bcc_together(self):
-        """Both CC and BCC should be handled simultaneously in O365."""
+        """Both Cc and Bcc should be handled simultaneously in O365."""
         client = _make_client()
         mock_message = MagicMock()
         mock_account = MagicMock()

--- a/tests/test_cc_bcc.py
+++ b/tests/test_cc_bcc.py
@@ -1,0 +1,301 @@
+"""
+Tests for CC and BCC email support.
+
+Covers:
+- SMTPClient.build_email() with cc_email_address and bcc_email_address parameters
+- Address whitelist validation for CC and BCC recipients
+- O365 send path with CC and BCC recipients
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from keboola.component.exceptions import UserException
+
+from client import SMTPClient
+
+# ==================== Helpers ====================
+
+
+def _make_client(**overrides) -> SMTPClient:
+    """Create an SMTPClient with mocked SMTP server initialization."""
+    defaults = dict(
+        sender_email_address="sender@example.com",
+        password="password",
+        server_host="smtp.example.com",
+        server_port=465,
+        connection_protocol="SSL",
+    )
+    defaults.update(overrides)
+    with patch.object(SMTPClient, "_init_ssl_smtp_server"):
+        return SMTPClient(**defaults)
+
+
+# ==================== Tests for build_email with CC/BCC ====================
+
+
+class TestBuildEmailCcBcc:
+    """Tests for build_email() with cc_email_address and bcc_email_address parameters."""
+
+    def test_no_cc_bcc_by_default(self):
+        """Without CC/BCC params, headers should not be set."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="user@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+        )
+        assert email["To"] == "user@example.com"
+        assert email["Cc"] is None
+        assert email["Bcc"] is None
+
+    def test_cc_single_address(self):
+        """Single CC address should be set in Cc header."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="cc@example.com",
+        )
+        assert email["To"] == "to@example.com"
+        assert email["Cc"] == "cc@example.com"
+        assert email["Bcc"] is None
+
+    def test_bcc_single_address(self):
+        """Single BCC address should be set in Bcc header."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            bcc_email_address="bcc@example.com",
+        )
+        assert email["To"] == "to@example.com"
+        assert email["Cc"] is None
+        assert email["Bcc"] == "bcc@example.com"
+
+    def test_cc_multiple_addresses(self):
+        """Multiple CC addresses (comma-separated) should be parsed and formatted."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="cc1@example.com, cc2@example.com",
+        )
+        assert email["Cc"] == "cc1@example.com, cc2@example.com"
+
+    def test_bcc_multiple_addresses_semicolon(self):
+        """Multiple BCC addresses (semicolon-separated) should be parsed and formatted."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            bcc_email_address="bcc1@example.com; bcc2@example.com",
+        )
+        assert email["Bcc"] == "bcc1@example.com, bcc2@example.com"
+
+    def test_cc_and_bcc_together(self):
+        """Both CC and BCC can be set simultaneously."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="cc@example.com",
+            bcc_email_address="bcc@example.com",
+        )
+        assert email["To"] == "to@example.com"
+        assert email["Cc"] == "cc@example.com"
+        assert email["Bcc"] == "bcc@example.com"
+
+    def test_empty_cc_bcc_strings_not_set(self):
+        """Empty strings for CC/BCC should not set headers."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="",
+            bcc_email_address="",
+        )
+        assert email["Cc"] is None
+        assert email["Bcc"] is None
+
+
+# ==================== Tests for whitelist validation with CC/BCC ====================
+
+
+class TestWhitelistCcBcc:
+    """Tests for address whitelist validation on CC and BCC recipients."""
+
+    def test_cc_allowed_by_whitelist(self):
+        """CC address matching whitelist should not raise."""
+        client = _make_client(address_whitelist=["*@allowed.com"])
+        email = client.build_email(
+            recipient_email_address="to@allowed.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="cc@allowed.com",
+        )
+        assert email["Cc"] == "cc@allowed.com"
+
+    def test_cc_rejected_by_whitelist(self):
+        """CC address not matching whitelist should raise UserException."""
+        client = _make_client(address_whitelist=["*@allowed.com"])
+        with pytest.raises(UserException, match="does not match any of the allowed masks"):
+            client.build_email(
+                recipient_email_address="to@allowed.com",
+                subject="Test",
+                rendered_plaintext_message="Body",
+                cc_email_address="cc@forbidden.com",
+            )
+
+    def test_bcc_allowed_by_whitelist(self):
+        """BCC address matching whitelist should not raise."""
+        client = _make_client(address_whitelist=["*@allowed.com"])
+        email = client.build_email(
+            recipient_email_address="to@allowed.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            bcc_email_address="bcc@allowed.com",
+        )
+        assert email["Bcc"] == "bcc@allowed.com"
+
+    def test_bcc_rejected_by_whitelist(self):
+        """BCC address not matching whitelist should raise UserException."""
+        client = _make_client(address_whitelist=["*@allowed.com"])
+        with pytest.raises(UserException, match="does not match any of the allowed masks"):
+            client.build_email(
+                recipient_email_address="to@allowed.com",
+                subject="Test",
+                rendered_plaintext_message="Body",
+                bcc_email_address="bcc@forbidden.com",
+            )
+
+    def test_multiple_cc_one_rejected(self):
+        """If one CC address in a multi-address string is disallowed, it should raise."""
+        client = _make_client(address_whitelist=["*@allowed.com"])
+        with pytest.raises(UserException, match="does not match any of the allowed masks"):
+            client.build_email(
+                recipient_email_address="to@allowed.com",
+                subject="Test",
+                rendered_plaintext_message="Body",
+                cc_email_address="cc1@allowed.com, cc2@forbidden.com",
+            )
+
+    def test_multiple_bcc_one_rejected(self):
+        """If one BCC address in a multi-address string is disallowed, it should raise."""
+        client = _make_client(address_whitelist=["*@allowed.com"])
+        with pytest.raises(UserException, match="does not match any of the allowed masks"):
+            client.build_email(
+                recipient_email_address="to@allowed.com",
+                subject="Test",
+                rendered_plaintext_message="Body",
+                bcc_email_address="bcc1@allowed.com; bcc2@forbidden.com",
+            )
+
+    def test_no_whitelist_allows_all_cc_bcc(self):
+        """Without whitelist, any CC/BCC addresses should be accepted."""
+        client = _make_client()
+        email = client.build_email(
+            recipient_email_address="to@any.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="cc@any.com",
+            bcc_email_address="bcc@any.com",
+        )
+        assert email["Cc"] == "cc@any.com"
+        assert email["Bcc"] == "bcc@any.com"
+
+
+# ==================== Tests for O365 with CC/BCC ====================
+
+
+class TestO365CcBcc:
+    """Tests for send_email_via_o365_oauth() with CC and BCC recipients."""
+
+    def test_o365_cc_added(self):
+        """CC recipients should be added via cc.add() on O365 message."""
+        client = _make_client()
+        mock_message = MagicMock()
+        mock_account = MagicMock()
+        mock_account.new_message.return_value = mock_message
+        client.smtp_server = mock_account
+
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="cc1@example.com, cc2@example.com",
+        )
+
+        client.send_email_via_o365_oauth(email, message_body="Body", attachments_paths=[])
+
+        assert mock_message.cc.add.call_count == 2
+        cc_calls = [call.args[0] for call in mock_message.cc.add.call_args_list]
+        assert cc_calls == ["cc1@example.com", "cc2@example.com"]
+
+    def test_o365_bcc_added(self):
+        """BCC recipients should be added via bcc.add() on O365 message."""
+        client = _make_client()
+        mock_message = MagicMock()
+        mock_account = MagicMock()
+        mock_account.new_message.return_value = mock_message
+        client.smtp_server = mock_account
+
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            bcc_email_address="bcc1@example.com; bcc2@example.com",
+        )
+
+        client.send_email_via_o365_oauth(email, message_body="Body", attachments_paths=[])
+
+        assert mock_message.bcc.add.call_count == 2
+        bcc_calls = [call.args[0] for call in mock_message.bcc.add.call_args_list]
+        assert bcc_calls == ["bcc1@example.com", "bcc2@example.com"]
+
+    def test_o365_no_cc_bcc_when_not_set(self):
+        """Without CC/BCC, cc.add() and bcc.add() should not be called."""
+        client = _make_client()
+        mock_message = MagicMock()
+        mock_account = MagicMock()
+        mock_account.new_message.return_value = mock_message
+        client.smtp_server = mock_account
+
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+        )
+
+        client.send_email_via_o365_oauth(email, message_body="Body", attachments_paths=[])
+
+        mock_message.cc.add.assert_not_called()
+        mock_message.bcc.add.assert_not_called()
+
+    def test_o365_cc_and_bcc_together(self):
+        """Both CC and BCC should be handled simultaneously in O365."""
+        client = _make_client()
+        mock_message = MagicMock()
+        mock_account = MagicMock()
+        mock_account.new_message.return_value = mock_message
+        client.smtp_server = mock_account
+
+        email = client.build_email(
+            recipient_email_address="to@example.com",
+            subject="Test",
+            rendered_plaintext_message="Body",
+            cc_email_address="cc@example.com",
+            bcc_email_address="bcc@example.com",
+        )
+
+        client.send_email_via_o365_oauth(email, message_body="Body", attachments_paths=[])
+
+        mock_message.cc.add.assert_called_once_with("cc@example.com")
+        mock_message.bcc.add.assert_called_once_with("bcc@example.com")
+        mock_message.send.assert_called_once()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -395,6 +395,80 @@ class TestValidateRunConfiguration:
         component.cfg = Configuration.load_from_dict(make_advanced_config(advanced_options=advanced_options))
         component._validate_run_configuration()  # must not raise
 
+    @pytest.mark.parametrize(
+        "config",
+        [
+            pytest.param(
+                make_advanced_config(
+                    send_to_all_recipients=False,
+                    advanced_options={"cc_email_address_column": "Cc"},
+                ),
+                id="advanced_cc_without_single_email",
+            ),
+            pytest.param(
+                make_advanced_config(
+                    send_to_all_recipients=False,
+                    advanced_options={"bcc_email_address_column": "Bcc"},
+                ),
+                id="advanced_bcc_without_single_email",
+            ),
+            pytest.param(
+                {
+                    "configuration_type": "basic",
+                    "send_to_all_recipients": False,
+                    "basic_options": {"cc_email_addresses": "cc@example.com"},
+                    "connection_config": {
+                        "use_oauth": False,
+                        "creds_config": {"sender_email_address": "s@s.com", "server_host": "h", "server_port": 25},
+                    },
+                },
+                id="basic_cc_without_single_email",
+            ),
+            pytest.param(
+                {
+                    "configuration_type": "basic",
+                    "send_to_all_recipients": False,
+                    "basic_options": {"bcc_email_addresses": "bcc@example.com"},
+                    "connection_config": {
+                        "use_oauth": False,
+                        "creds_config": {"sender_email_address": "s@s.com", "server_host": "h", "server_port": 25},
+                    },
+                },
+                id="basic_bcc_without_single_email",
+            ),
+        ],
+    )
+    def test_cc_bcc_without_single_email_raises(self, component, config):
+        """Cc/Bcc fields set while send_to_all_recipients is False must raise UserException."""
+        component.cfg = Configuration.load_from_dict(config)
+        with pytest.raises(UserException, match="Cc and Bcc are only available when 'Send as Single Email' is enabled"):
+            component._validate_run_configuration()
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            pytest.param(
+                make_advanced_config(send_to_all_recipients=False),
+                id="advanced_no_cc_bcc",
+            ),
+            pytest.param(
+                make_advanced_config(
+                    send_to_all_recipients=True,
+                    advanced_options={"cc_email_address_column": "Cc", "bcc_email_address_column": "Bcc"},
+                ),
+                id="advanced_cc_bcc_with_single_email",
+            ),
+            pytest.param(
+                make_advanced_config(configuration_type="basic"),
+                id="basic_no_cc_bcc",
+            ),
+        ],
+    )
+    def test_cc_bcc_guard_does_not_raise(self, component, config):
+        """Guard must not raise for valid combinations (no Cc/Bcc, or single-email mode enabled)."""
+        component.cfg = Configuration.load_from_dict(config)
+        component._validate_run_configuration()  # must not raise
+
 
 # ==================== Tests for _resolve_data_source_table_path() ====================
 


### PR DESCRIPTION
## Summary

Adds Cc and Bcc recipient support to the Email SMTP Sender component ([CFTL-478](https://linear.app/keboola/issue/CFTL-478/support-15892-kds-teamapp-email-smtp-sender-from-slsp)).

- **Basic mode**: Cc/Bcc text inputs (comma/semicolon-separated)
- **Advanced mode**: Cc/Bcc column selectors
- All Cc/Bcc addresses are validated against the address whitelist (same as To)
- Both transports covered: O365 OAuth path adds Cc/Bcc via `cc.add()` / `bcc.add()`; SMTP path uses standard `smtplib.send_message()`

## UX

Cc/Bcc only make sense when sending one email to multiple recipients. The "Send as Single Email (enables Cc and Bcc fields)" checkbox now sits at the top of the form and:

- **Unchecked** (default): Cc/Bcc fields are hidden. Each To address gets its own individual email — same as before.
- **Checked**: Cc/Bcc fields appear and behave like composing a message in Outlook.

A `UserException` guards against manually-edited configs that set Cc/Bcc while `send_to_all_recipients = false`, since that combination would silently send one Cc/Bcc copy per individual To email.

## Backward compatibility

Fully backward compatible — Cc/Bcc are new optional fields. Existing configurations without them continue to work unchanged.

## Tests

- `test_cc_bcc.py`: 18 tests (headers, parsing, whitelist, O365)
- `test_validation.py`: 7 new tests covering the guard