### PR TITLE
feat: apply image_parameters.global_config required values at runtime

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import json
 import logging
@@ -33,6 +34,7 @@ KEY_HTML_TEMPLATE_DEFINITION = "html_template_definition"
 KEY_ALLOWED_HOSTS = "allowed_hosts"
 KEY_ADDRESS_WHITELIST = "address_whitelist"
 KEY_DISABLE_ATTACHMENTS = "disable_attachments"
+KEY_GLOBAL_CONFIG = "global_config"
 
 SLEEP_INTERVAL = 0.1
 
@@ -209,7 +211,9 @@ class Component(ComponentBase):
 
     def _init_configuration(self) -> None:
         self.validate_configuration_parameters(Configuration.get_dataclass_required_parameters())
-        self.cfg: Configuration = Configuration.load_from_dict(self.configuration.parameters)
+        parameters = copy.deepcopy(self.configuration.parameters or {})
+        self.apply_global_config(parameters)
+        self.cfg: Configuration = Configuration.load_from_dict(parameters)
 
     def _validate_run_configuration(self) -> None:
         """
@@ -332,6 +336,42 @@ class Component(ComponentBase):
 
             if not match:
                 raise UserException(f"Host {creds_config.server_host}:{creds_config.server_port} is not allowed")
+
+    def apply_global_config(self, parameters: dict) -> None:
+        """Merge required values from image_parameters.global_config into the user parameters dict.
+
+        The Keboola UI displays global_config values as if they were part of the user's
+        configuration, but they are not actually written to the stored config when the user
+        saves the form. Without this merge, the component would see fields missing or
+        different from what the UI displayed. We do the merge here so the component matches
+        what the user saw. Fields missing from the user configuration are filled silently.
+        If the user explicitly set a different value, a UserException is raised — locked
+        values cannot be overridden.
+        """
+        image_parameters = self.configuration.image_parameters or {}
+        global_config = image_parameters.get(KEY_GLOBAL_CONFIG)
+        if not isinstance(global_config, dict):
+            return
+
+        self._apply_required_values(global_config, parameters, "")
+
+    @staticmethod
+    def _apply_required_values(required: dict, target: dict, path: str) -> None:
+        for key, required_value in required.items():
+            sub_path = f"{path}.{key}" if path else key
+            if isinstance(required_value, dict):
+                if not isinstance(target.get(key), dict):
+                    target[key] = {}
+                Component._apply_required_values(required_value, target[key], sub_path)
+            else:
+                existing = target.get(key)
+                if existing is None:
+                    target[key] = required_value
+                elif existing != required_value:
+                    raise UserException(
+                        f"Field '{sub_path}' is centrally managed by your stack and "
+                        f"cannot be overridden in your configuration."
+                    )
 
     @staticmethod
     def load_email_data_table_path(in_tables, email_data_table_name):

--- a/src/component.py
+++ b/src/component.py
@@ -924,9 +924,8 @@ class Component(ComponentBase):
         self._client.smtp_server.close()
 
     def test_smtp_server_connection_(self) -> ValidationResult:
-        connection_config = ConnectionConfig.load_from_dict(self.configuration.parameters["connection_config"])
         try:
-            self.init_client(connection_config=connection_config)
+            self.init_client()
             return ValidationResult("✅ Connection established successfully", MessageType.SUCCESS)
         except Exception as e:
             return ValidationResult(f"❌ Connection couldn't be established. Error: {e}", MessageType.DANGER)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -15,6 +15,7 @@ Tests cover:
 - _parse_template_placeholders() static method
 """
 
+import copy
 import shutil
 import tempfile
 from contextlib import contextmanager
@@ -1569,3 +1570,123 @@ class TestValidateConfig:
             comp.validate_single_table_.assert_called_once()
         else:
             comp.validate_single_table_.assert_not_called()
+
+
+# ==================== apply_global_config tests ====================
+
+
+class TestApplyGlobalConfig:
+    """Tests for apply_global_config() method."""
+
+    @staticmethod
+    @contextmanager
+    def _make_component(image_parameters: dict | None = None):
+        comp = Component.__new__(Component)
+
+        mock_config = MagicMock()
+        mock_config.image_parameters = image_parameters
+
+        with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+            mock_conf_prop.return_value = mock_config
+            yield comp
+
+    def test_no_global_config(self):
+        """No global_config in image_parameters — parameters unchanged."""
+        params = make_advanced_config()
+        original = copy.deepcopy(params)
+        with self._make_component(image_parameters={}) as comp:
+            comp.apply_global_config(params)
+        assert params == original
+
+    def test_empty_global_config(self):
+        """Empty global_config — parameters unchanged."""
+        params = make_advanced_config()
+        original = copy.deepcopy(params)
+        with self._make_component(image_parameters={"global_config": {}}) as comp:
+            comp.apply_global_config(params)
+        assert params == original
+
+    def test_no_image_parameters(self):
+        """image_parameters is None — parameters unchanged."""
+        params = make_advanced_config()
+        original = copy.deepcopy(params)
+        with self._make_component(image_parameters=None) as comp:
+            comp.apply_global_config(params)
+        assert params == original
+
+    def test_use_oauth_matches(self):
+        """use_oauth matches global_config — no-op, no exception."""
+        params = make_advanced_config()
+        with self._make_component(
+            image_parameters={"global_config": {"connection_config": {"use_oauth": False}}},
+        ) as comp:
+            comp.apply_global_config(params)
+        assert params["connection_config"]["use_oauth"] is False
+
+    def test_use_oauth_mismatch_raises(self):
+        """use_oauth differs from global_config — UserException raised."""
+        params = make_advanced_config(connection_config={"use_oauth": True})
+        with self._make_component(
+            image_parameters={"global_config": {"connection_config": {"use_oauth": False}}},
+        ) as comp:
+            with pytest.raises(UserException, match="connection_config.use_oauth.*centrally managed"):
+                comp.apply_global_config(params)
+
+    def test_missing_field_filled_silently(self):
+        """User config missing the locked field — filled in, no exception."""
+        params = make_advanced_config()
+        params["connection_config"]["creds_config"].pop("sender_email_address", None)
+        with self._make_component(
+            image_parameters={
+                "global_config": {"connection_config": {"creds_config": {"sender_email_address": "locked@example.com"}}}
+            },
+        ) as comp:
+            comp.apply_global_config(params)
+        assert params["connection_config"]["creds_config"]["sender_email_address"] == "locked@example.com"
+
+    def test_sender_email_mismatch_raises(self):
+        """sender_email_address differs — UserException raised."""
+        params = make_advanced_config(connection_config={"creds_config": {"sender_email_address": "other@example.com"}})
+        with self._make_component(
+            image_parameters={
+                "global_config": {"connection_config": {"creds_config": {"sender_email_address": "locked@example.com"}}}
+            },
+        ) as comp:
+            with pytest.raises(
+                UserException, match="connection_config.creds_config.sender_email_address.*centrally managed"
+            ):
+                comp.apply_global_config(params)
+
+    def test_first_mismatch_raises_when_other_fields_match(self):
+        """When several fields are locked and only one mismatches — that field's UserException is raised."""
+        params = make_advanced_config(
+            connection_config={
+                "use_oauth": False,
+                "creds_config": {
+                    "sender_email_address": "locked@example.com",
+                    "server_host": "wrong-host.com",
+                },
+            }
+        )
+        with self._make_component(
+            image_parameters={
+                "global_config": {
+                    "connection_config": {
+                        "use_oauth": False,
+                        "creds_config": {
+                            "sender_email_address": "locked@example.com",
+                            "server_host": "correct-host.com",
+                        },
+                    }
+                }
+            },
+        ) as comp:
+            with pytest.raises(UserException, match="connection_config.creds_config.server_host.*centrally managed"):
+                comp.apply_global_config(params)
+
+    def test_top_level_field_mismatch_raises(self):
+        """Top-level field locked and user value differs — UserException raised."""
+        params = make_advanced_config(dry_run=False)
+        with self._make_component(image_parameters={"global_config": {"dry_run": True}}) as comp:
+            with pytest.raises(UserException, match="dry_run.*centrally managed"):
+                comp.apply_global_config(params)


### PR DESCRIPTION
## Summary

Companion to [keboola/infrastructure-plugin-update-components#765](https://github.com/keboola/infrastructure-plugin-update-components/pull/765) for [CFTL-504](https://linear.app/keboola/issue/CFTL-504).

Adds `apply_global_config()` so the component follows `image_parameters.global_config` at runtime. Per-stack locks flow into the user's effective config without a separate per-component forcelist or schema clone.

## Why

The Keboola UI already follows `global_config` as the source of truth for default/locked values. The component runtime should follow the same source instead of relying on its own mechanism (`allowed_sender_email_addresses`) — otherwise the same restriction lives in multiple places and drifts. CFTL-504 is a concrete instance of that drift.

Once `global_config` is the active path, the legacy `allowed_sender_email_addresses` guard can be retired.

## What it does

`apply_global_config()` runs in `_init_configuration()`, before the dataclass is loaded. For each leaf in `image_parameters.global_config`:

- **field missing in the user config → filled silently.** This is the default path under normal UI usage: locked fields are rendered by the UI from `global_config`, are not editable, and are not written to the stored config when the user saves the form.
- **field present but different → run halts with a `UserException`.** Only reachable when a user has edited the raw JSON in debug mode to override a locked value.
- **field matches → no-op.**

Fully generic — any field at any nesting level under `global_config` is enforced without per-field code changes.

## Also fixes

The `testConnection` sync action — previously did a raw `parameters["connection_config"]` lookup that crashed when `connection_config` was supplied entirely by `global_config`. Now uses the merged user-config + global_config the same way the run path does, so Test Connection works on stacks that lock connection settings centrally.

## Tests

`TestApplyGlobalConfig` in `tests/test_validation.py` — 9 tests covering no-op, match, silent fill, single- and multi-field mismatch (raises `UserException`), top-level field.

## Verified end-to-end

Three configs on the private dev test stack:

- ✅ **Locked values missing** → silent fill, run continues to SMTP login as expected.
- ✅ **Locked values set to forbidden values (Debug mode)** → halts with user error `Field 'connection_config.use_oauth' is centrally managed by your stack and cannot be overridden in your configuration.`
- ✅ **Locked values manually added matching the lock (Debug mode)** → no-op, run continues to SMTP login as expected.

Plus CF testing project with no `global_config` → no regression on the existing flow.