### PR TITLE
feat: add per-recipient send-status logging for job-log durability

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -419,6 +419,8 @@ class Component(ComponentBase):
     ) -> None:
         continue_on_error = self.cfg.continue_on_error
         dry_run = self.cfg.dry_run
+        ok_count = 0
+        error_count = 0
         use_advanced_options = self.cfg.configuration_type == "advanced"
         basic_options = self.cfg.basic_options
         advanced_options = self.cfg.advanced_options
@@ -581,11 +583,15 @@ class Component(ComponentBase):
                             html_message_body=rendered_html_message,
                             attachments_paths=attachment_paths,
                         )
+                        logging.info(f"Email sent successfully to {email_['To']}")
+                        ok_count += 1
 
                     except Exception as e:
                         error_message = str(e)
                         status = "ERROR"
                         self._results_writer.errors = True
+                        logging.warning(f"Failed to send email to {email_['To']}: {error_message}")
+                        error_count += 1
 
                 rendered_html_message_writable = ""
                 if rendered_html_message:
@@ -616,6 +622,8 @@ class Component(ComponentBase):
                 time.sleep(SLEEP_INTERVAL)
 
             except Exception as e:
+                logging.warning(f"Failed to process row for recipient {recipient_email_address}: {e}")
+                error_count += 1
                 self._results_writer.writerow(
                     {
                         **general_error_row,
@@ -628,6 +636,7 @@ class Component(ComponentBase):
                 if not continue_on_error:
                     break
 
+        logging.info(f"Email send loop complete: {ok_count} sent, {error_count} failed")
         try:
             in_table.close()
         except NameError:

--- a/tests/test_send_logging.py
+++ b/tests/test_send_logging.py
@@ -1,0 +1,235 @@
+"""
+Tests for per-recipient send-status logging in send_emails().
+
+Covers:
+- Success log: "Email sent successfully to ..." is emitted after successful send
+- Failure log: "Failed to send email to ...: <error>" is emitted on SMTP exception
+- Outer-failure log: "Failed to process row for recipient ...: <error>" on row-level errors
+- Summary log: "Email send loop complete: N sent, M failed" at end of loop
+"""
+
+import csv
+import logging
+import os
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from component import Component
+from configuration import Configuration
+
+
+def _make_advanced_config(**overrides) -> dict:
+    config = {
+        "configuration_type": "advanced",
+        "connection_config": {
+            "use_oauth": False,
+            "creds_config": {
+                "sender_email_address": "test@example.com",
+                "server_host": "smtp.example.com",
+                "server_port": 465,
+            },
+        },
+        "advanced_options": {
+            "email_data_table_name": "email_data.csv",
+            "recipient_email_address_column": "email",
+            "subject_config": {
+                "subject_source": "from_template_definition",
+                "subject_template_definition": "Test Subject",
+            },
+            "message_body_config": {
+                "message_body_source": "from_template_definition",
+                "use_html_template": False,
+                "plaintext_template_definition": "Hello",
+            },
+            "include_attachments": False,
+            "attachments_config": {
+                "attachments_source": "all_input_files",
+            },
+        },
+        "continue_on_error": True,
+        "dry_run": False,
+    }
+    for key, value in overrides.items():
+        if isinstance(value, dict) and key in config and isinstance(config[key], dict):
+            config[key].update(value)
+        else:
+            config[key] = value
+    return config
+
+
+@pytest.fixture
+def send_component(tmp_path):
+    """Create a Component wired for send_emails() with a real CSV input table."""
+    comp = Component.__new__(Component)
+    comp.cfg = Configuration.load_from_dict(_make_advanced_config())
+
+    mock_config = MagicMock()
+    mock_config.parameters = _make_advanced_config()
+
+    with patch.object(type(comp), "configuration", new_callable=PropertyMock) as mock_conf_prop:
+        mock_conf_prop.return_value = mock_config
+        comp.environment_variables = MagicMock()
+
+        # Wire a real results CSV writer
+        results_path = tmp_path / "results.csv"
+        results_file = open(results_path, "w", newline="")
+        from component import RESULT_TABLE_COLUMNS
+
+        comp._results_writer = csv.DictWriter(results_file, fieldnames=RESULT_TABLE_COLUMNS)
+        comp._results_writer.writeheader()
+        comp._results_writer.errors = False
+
+        # Mock client
+        comp._client = MagicMock()
+        comp._client.sender_email_address = "test@example.com"
+        comp._client.disable_attachments = False
+
+        def _build_email(**kwargs):
+            msg = MagicMock()
+            msg.__getitem__ = lambda self, key: {
+                "To": kwargs.get("recipient_email_address", ""),
+                "From": "test@example.com",
+                "Subject": kwargs.get("subject", "Test Subject"),
+                "Cc": kwargs.get("cc_email_address"),
+                "Bcc": kwargs.get("bcc_email_address"),
+            }.get(key)
+            return msg
+
+        comp._client.build_email.side_effect = _build_email
+
+        yield comp
+        results_file.close()
+
+
+def _write_email_csv(path, rows: list[dict[str, str]]) -> str:
+    filepath = os.path.join(path, "email_data.csv")
+    with open(filepath, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    return filepath
+
+
+class TestSuccessLog:
+    """After successful send_email(), an info log is emitted per recipient."""
+
+    def test_success_log_emitted(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(str(tmp_path), [{"email": "alice@example.com"}])
+        send_component._client.send_email.return_value = None
+
+        with caplog.at_level(logging.INFO):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        assert any("Email sent successfully to alice@example.com" in r.message for r in caplog.records)
+
+    def test_success_log_multiple_recipients(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(
+            str(tmp_path),
+            [{"email": "alice@example.com"}, {"email": "bob@example.com"}],
+        )
+        send_component._client.send_email.return_value = None
+
+        with caplog.at_level(logging.INFO):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        messages = [r.message for r in caplog.records]
+        assert any("Email sent successfully to alice@example.com" in m for m in messages)
+        assert any("Email sent successfully to bob@example.com" in m for m in messages)
+
+
+class TestFailureLog:
+    """On SMTP exception, a warning log is emitted with the error message."""
+
+    def test_failure_log_emitted(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(str(tmp_path), [{"email": "fail@example.com"}])
+        send_component._client.send_email.side_effect = Exception("Connection refused")
+
+        with caplog.at_level(logging.WARNING):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        assert any("Failed to send email to fail@example.com: Connection refused" in r.message for r in caplog.records)
+
+    def test_failure_log_contains_error_detail(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(str(tmp_path), [{"email": "fail@example.com"}])
+        send_component._client.send_email.side_effect = TimeoutError("SMTP timeout after 30s")
+
+        with caplog.at_level(logging.WARNING):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("SMTP timeout after 30s" in r.message for r in warning_records)
+
+
+class TestOuterFailureLog:
+    """Row-level processing errors (before SMTP call) emit a warning log."""
+
+    def test_outer_failure_log_emitted(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(str(tmp_path), [{"email": "user@example.com"}])
+        send_component._client.build_email.side_effect = KeyError("missing_column")
+
+        with caplog.at_level(logging.WARNING):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        assert any("Failed to process row for recipient user@example.com" in r.message for r in caplog.records)
+
+
+class TestSummaryLog:
+    """End-of-loop summary log reports ok and error counts."""
+
+    def test_summary_all_ok(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(
+            str(tmp_path),
+            [{"email": "a@example.com"}, {"email": "b@example.com"}],
+        )
+        send_component._client.send_email.return_value = None
+
+        with caplog.at_level(logging.INFO):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        assert any("Email send loop complete: 2 sent, 0 failed" in r.message for r in caplog.records)
+
+    def test_summary_mixed(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(
+            str(tmp_path),
+            [{"email": "ok@example.com"}, {"email": "fail@example.com"}],
+        )
+        send_component._client.send_email.side_effect = [None, Exception("error")]
+
+        with caplog.at_level(logging.INFO):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        assert any("Email send loop complete: 1 sent, 1 failed" in r.message for r in caplog.records)
+
+    def test_summary_all_failed(self, send_component, tmp_path, caplog):
+        csv_path = _write_email_csv(str(tmp_path), [{"email": "fail@example.com"}])
+        send_component._client.send_email.side_effect = Exception("down")
+
+        with caplog.at_level(logging.INFO):
+            send_component.send_emails(
+                attachments_paths_by_filename={},
+                email_data_table_path=csv_path,
+            )
+
+        assert any("Email send loop complete: 0 sent, 1 failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Adds per-recipient send-status logging to `send_emails()` so that email delivery outcomes are visible in the Keboola job log even when the job is terminated and the `results` table is not promoted to Storage.

Three log lines added in `src/component.py`:
1. **Success log** (`logging.info`): `Email sent successfully to <recipient>` — emitted after `send_email()` returns successfully
2. **Failure log** (`logging.warning`): `Failed to send email to <recipient>: <error>` — emitted when `send_email()` raises an exception
3. **Outer-failure log** (`logging.warning`): `Failed to process row for recipient <recipient>: <error>` — emitted for row-level processing errors that bypass the SMTP call
4. **Summary log** (`logging.info`): `Email send loop complete: N sent, M failed` — emitted at end of loop

Three states are now distinguishable from the job log alone (no `results` table needed):
- **Sent**: pre-send log + post-send-OK log
- **Failed**: pre-send log + post-send-ERROR log
- **In-flight at termination**: pre-send log only (no matching post-send line)

~10 LOC change. No schema change. No new dependencies. Backward compatible — pure log addition.

Refs: [CFTL-663](https://linear.app/keboola/issue/CFTL-663), [SUPPORT-16424](https://keboola.atlassian.net/browse/SUPPORT-16424)

## Review & Testing Checklist for Human
- [ ] Verify the three new log lines appear in job logs during a real SMTP send (success case)
- [ ] Trigger a send failure (e.g. invalid SMTP credentials or unreachable host) and confirm the warning log appears with the error message
- [ ] Terminate a job mid-send and confirm the pre-send line appears without a matching post-send line for the in-flight email

### Notes
- All 184 existing tests continue to pass unchanged
- 8 new tests in `tests/test_send_logging.py` cover: success log, failure log, outer-failure log, and summary log (all-ok / mixed / all-failed)
- Pre-commit hooks (ruff format, ruff check, pytest, ty) all pass

## Release Notes
**Justification, description**

Per-recipient send-status logging added to the SMTP sender job log. Previously, send outcomes were only written to the `results` output table, which is lost when a job is terminated. Now each send attempt logs its outcome (success/failure) directly to the job log.

**Plans for Customer Communication**

Reply to SUPPORT-16424 (Martin Dobeš / CSAS) confirming per-recipient log lines now appear in job logs including for terminated jobs.

**Impact Analysis**

Additive-only change — no behavioral changes to email sending, configuration, or output table schema. Only new `logging.info`/`logging.warning` calls added.

**Deployment Plan**

Standard tag-and-release flow. Tag as next patch version.

**Rollback Plan**

Revert the commit — no data or schema changes to undo.

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/03eaa88cd554418d9ac1779e70360fbe
Requested by: @Jakuboola